### PR TITLE
fix: correct branch reference in tag-release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: RoboFinSystems/robosystems-typescript-client
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.branch_ref }}
           token: ${{ secrets.ACTIONS_TOKEN }}
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
Updates the branch reference in the GitHub Actions tag-release workflow to ensure proper automation functionality.

## Changes Made
- Fixed incorrect branch reference in `.github/workflows/tag-release.yml`
- Ensures the workflow triggers on the correct branch for release tagging

## Key Improvements
- **CI/CD Reliability**: Corrects workflow configuration to prevent failed or missed release deployments
- **Development Process**: Ensures automated tagging works as expected for production releases

## Breaking Changes
None - This is a configuration fix that improves existing functionality.

## Testing Notes for Reviewers
- ✅ Verify the branch reference matches the intended target branch
- ✅ Confirm workflow syntax is valid
- ✅ Check that this aligns with current branching strategy
- ✅ Consider testing the workflow on a test branch if possible

## Browser Compatibility
No browser compatibility impact - this change only affects CI/CD pipeline configuration.

## Additional Notes
This fix ensures our release automation works correctly and prevents potential deployment issues. The change is minimal but critical for maintaining our release process integrity.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/gh-ref`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>