### PR TITLE
Refactor: Replace 'classification' with 'trait' across GraphQL layer

### DIFF
--- a/clients/graphql/generated/graphql.ts
+++ b/clients/graphql/generated/graphql.ts
@@ -25,7 +25,6 @@ export type Scalars = {
 export type Account = {
   accountType: Maybe<Scalars['String']['output']>
   balanceType: Scalars['String']['output']
-  classification: Maybe<Scalars['String']['output']>
   code: Maybe<Scalars['String']['output']>
   currency: Scalars['String']['output']
   depth: Scalars['Int']['output']
@@ -38,6 +37,7 @@ export type Account = {
   name: Scalars['String']['output']
   parentId: Maybe<Scalars['String']['output']>
   subClassification: Maybe<Scalars['String']['output']>
+  trait: Maybe<Scalars['String']['output']>
 }
 
 export type AccountList = {
@@ -48,11 +48,11 @@ export type AccountList = {
 export type AccountRollupGroup = {
   accounts: Array<AccountRollupRow>
   balanceType: Scalars['String']['output']
-  classification: Scalars['String']['output']
   reportingElementId: Scalars['String']['output']
   reportingName: Scalars['String']['output']
   reportingQname: Scalars['String']['output']
   total: Scalars['Float']['output']
+  trait: Scalars['String']['output']
 }
 
 export type AccountRollupRow = {
@@ -81,12 +81,12 @@ export type AccountTreeNode = {
   accountType: Maybe<Scalars['String']['output']>
   balanceType: Scalars['String']['output']
   children: Array<AccountTreeNode>
-  classification: Maybe<Scalars['String']['output']>
   code: Maybe<Scalars['String']['output']>
   depth: Scalars['Int']['output']
   id: Scalars['ID']['output']
   isActive: Scalars['Boolean']['output']
   name: Scalars['String']['output']
+  trait: Maybe<Scalars['String']['output']>
 }
 
 export type Agent = {
@@ -188,7 +188,6 @@ export type DraftLineItem = {
 
 export type Element = {
   balanceType: Scalars['String']['output']
-  classification: Maybe<Scalars['String']['output']>
   code: Maybe<Scalars['String']['output']>
   depth: Scalars['Int']['output']
   description: Maybe<Scalars['String']['output']>
@@ -206,6 +205,7 @@ export type Element = {
   source: Scalars['String']['output']
   subClassification: Maybe<Scalars['String']['output']>
   taxonomyId: Maybe<Scalars['String']['output']>
+  trait: Maybe<Scalars['String']['output']>
 }
 
 export type ElementList = {
@@ -214,12 +214,12 @@ export type ElementList = {
 }
 
 export type FactRow = {
-  classification: Maybe<Scalars['String']['output']>
   depth: Scalars['Int']['output']
   elementId: Scalars['String']['output']
   elementName: Scalars['String']['output']
   elementQname: Scalars['String']['output']
   isSubtotal: Scalars['Boolean']['output']
+  trait: Maybe<Scalars['String']['output']>
   values: Array<Maybe<Scalars['Float']['output']>>
 }
 
@@ -302,7 +302,7 @@ export type InformationBlock = {
 }
 
 export type InformationBlockClassification = {
-  /** One of the categories in the `public.classifications` CHECK constraint — e.g. 'concept_arrangement', 'member_arrangement', 'named_disclosure' for association-level; 'liquidity', 'activityType', etc. for element-level. */
+  /** One of the 3 association-level categories in the `public.classifications` CHECK constraint: 'concept_arrangement', 'member_arrangement', or 'named_disclosure'. */
   category: Scalars['String']['output']
   /** AI/adapter-supplied confidence (0.0-1.0). Null for deterministic library-seeded rows. */
   confidence: Maybe<Scalars['Float']['output']>
@@ -320,7 +320,7 @@ export type InformationBlockConnection = {
   arcrole: Maybe<Scalars['String']['output']>
   /** presentation | calculation | mapping | equivalence | general-special | essence-alias */
   associationType: Scalars['String']['output']
-  /** Association-level classifications (Phase epsilon) — concept_arrangement, member_arrangement, named_disclosure rows from the junction. Empty for library-seeded associations that haven't been classified yet. */
+  /** Association-level classifications — concept_arrangement, member_arrangement, named_disclosure rows from the junction. Empty for library-seeded associations that haven't been classified yet. */
   classifications: Array<InformationBlockClassification>
   fromElementId: Scalars['String']['output']
   id: Scalars['String']['output']
@@ -546,8 +546,6 @@ export type LibraryAssociation = {
 export type LibraryElement = {
   /** debit | credit */
   balanceType: Scalars['String']['output']
-  /** FASB elementsOfFinancialStatements axis: asset | contraAsset | liability | contraLiability | equity | contraEquity | temporaryEquity | revenue | expense | expenseReversal | gain | loss | comprehensiveIncome | investmentByOwners | distributionToOwners | metric (derived subtotals, not SFAC 6 primary elements). Null for structural rows. */
-  classification: Maybe<Scalars['String']['output']>
   /** concept | abstract | axis | member | hypercube */
   elementType: Scalars['String']['output']
   id: Scalars['String']['output']
@@ -565,6 +563,8 @@ export type LibraryElement = {
   /** fac | us-gaap | rs-gaap | … */
   source: Scalars['String']['output']
   taxonomyId: Maybe<Scalars['String']['output']>
+  /** FASB elementsOfFinancialStatements axis: asset | contraAsset | liability | contraLiability | equity | contraEquity | temporaryEquity | revenue | expense | expenseReversal | gain | loss | comprehensiveIncome | investmentByOwners | distributionToOwners | metric (derived subtotals, not SFAC 6 primary elements). Null for structural rows. */
+  trait: Maybe<Scalars['String']['output']>
 }
 
 export type LibraryElementArc = {
@@ -582,11 +582,11 @@ export type LibraryElementArc = {
 }
 
 export type LibraryElementClassification = {
-  /** Classification axis (e.g. elementsOfFinancialStatements) */
+  /** Trait axis (e.g. elementsOfFinancialStatements) */
   category: Scalars['String']['output']
   /** Value within the axis (e.g. expense) */
   identifier: Scalars['String']['output']
-  /** True for the element's primary EFS classification */
+  /** True for the element's primary EFS trait assignment */
   isPrimary: Scalars['Boolean']['output']
   /** Human-readable name */
   name: Maybe<Scalars['String']['output']>
@@ -655,13 +655,13 @@ export type MappedTrialBalance = {
 
 export type MappedTrialBalanceRow = {
   balanceType: Maybe<Scalars['String']['output']>
-  classification: Maybe<Scalars['String']['output']>
   netBalance: Scalars['Float']['output']
   qname: Scalars['String']['output']
   reportingElementId: Scalars['String']['output']
   reportingName: Scalars['String']['output']
   totalCredits: Scalars['Float']['output']
   totalDebits: Scalars['Float']['output']
+  trait: Maybe<Scalars['String']['output']>
 }
 
 export type MappingCoverage = {
@@ -1248,7 +1248,6 @@ export type TaxonomyBlockAssociation = {
 
 export type TaxonomyBlockElement = {
   balanceType: Maybe<Scalars['String']['output']>
-  classification: Maybe<Scalars['String']['output']>
   depth: Maybe<Scalars['Int']['output']>
   elementType: Scalars['String']['output']
   id: Scalars['String']['output']
@@ -1258,6 +1257,7 @@ export type TaxonomyBlockElement = {
   parentQname: Maybe<Scalars['String']['output']>
   periodType: Maybe<Scalars['String']['output']>
   qname: Maybe<Scalars['String']['output']>
+  trait: Maybe<Scalars['String']['output']>
 }
 
 export type TaxonomyBlockRule = {
@@ -1295,20 +1295,20 @@ export type TrialBalanceRow = {
   accountId: Scalars['String']['output']
   accountName: Scalars['String']['output']
   accountType: Maybe<Scalars['String']['output']>
-  classification: Maybe<Scalars['String']['output']>
   netBalance: Scalars['Float']['output']
   totalCredits: Scalars['Float']['output']
   totalDebits: Scalars['Float']['output']
+  trait: Maybe<Scalars['String']['output']>
 }
 
 export type UnmappedElement = {
   balanceType: Scalars['String']['output']
-  classification: Maybe<Scalars['String']['output']>
   code: Maybe<Scalars['String']['output']>
   externalSource: Maybe<Scalars['String']['output']>
   id: Scalars['String']['output']
   name: Scalars['String']['output']
   suggestedTargets: Array<SuggestedTarget>
+  trait: Maybe<Scalars['String']['output']>
 }
 
 export type ValidationCheck = {
@@ -1516,7 +1516,7 @@ export type GetLedgerAccountRollupsQuery = {
       reportingElementId: string
       reportingName: string
       reportingQname: string
-      classification: string
+      trait: string
       balanceType: string
       total: number
       accounts: Array<{
@@ -1540,7 +1540,7 @@ export type GetLedgerAccountTreeQuery = {
       id: string
       code: string | null
       name: string
-      classification: string | null
+      trait: string | null
       accountType: string | null
       balanceType: string
       depth: number
@@ -1549,7 +1549,7 @@ export type GetLedgerAccountTreeQuery = {
         id: string
         code: string | null
         name: string
-        classification: string | null
+        trait: string | null
         accountType: string | null
         balanceType: string
         depth: number
@@ -1558,7 +1558,7 @@ export type GetLedgerAccountTreeQuery = {
           id: string
           code: string | null
           name: string
-          classification: string | null
+          trait: string | null
           accountType: string | null
           balanceType: string
           depth: number
@@ -1567,7 +1567,7 @@ export type GetLedgerAccountTreeQuery = {
             id: string
             code: string | null
             name: string
-            classification: string | null
+            trait: string | null
             accountType: string | null
             balanceType: string
             depth: number
@@ -1593,7 +1593,6 @@ export type ListLedgerAccountsQuery = {
       code: string | null
       name: string
       description: string | null
-      classification: string | null
       subClassification: string | null
       balanceType: string
       parentId: string | null
@@ -1646,7 +1645,6 @@ export type ListLedgerElementsQuery = {
       description: string | null
       qname: string | null
       namespace: string | null
-      classification: string | null
       subClassification: string | null
       balanceType: string
       periodType: string
@@ -1876,7 +1874,7 @@ export type GetLedgerMappedTrialBalanceQuery = {
       reportingElementId: string
       qname: string
       reportingName: string
-      classification: string | null
+      trait: string | null
       balanceType: string | null
       totalDebits: number
       totalCredits: number
@@ -2142,7 +2140,7 @@ export type GetLedgerStatementQuery = {
       elementId: string
       elementQname: string
       elementName: string
-      classification: string | null
+      trait: string | null
       values: Array<number | null>
       isSubtotal: boolean
       depth: number
@@ -2298,7 +2296,7 @@ export type GetLedgerTrialBalanceQuery = {
       accountId: string
       accountCode: string
       accountName: string
-      classification: string | null
+      trait: string | null
       accountType: string | null
       totalDebits: number
       totalCredits: number
@@ -2316,7 +2314,7 @@ export type ListLedgerUnmappedElementsQuery = {
     id: string
     code: string | null
     name: string
-    classification: string | null
+    trait: string | null
     balanceType: string
     externalSource: string | null
     suggestedTargets: Array<{
@@ -2369,7 +2367,7 @@ export type GetLibraryElementArcsQuery = {
     taxonomyName: string | null
     structureId: string | null
     structureName: string | null
-    peer: { id: string; qname: string; name: string; classification: string | null; source: string }
+    peer: { id: string; qname: string; name: string; trait: string | null; source: string }
   }>
 }
 
@@ -2392,18 +2390,12 @@ export type GetLibraryElementEquivalentsQueryVariables = Exact<{
 
 export type GetLibraryElementEquivalentsQuery = {
   libraryElementEquivalents: {
-    element: {
-      id: string
-      qname: string
-      name: string
-      classification: string | null
-      source: string
-    }
+    element: { id: string; qname: string; name: string; trait: string | null; source: string }
     equivalents: Array<{
       id: string
       qname: string
       name: string
-      classification: string | null
+      trait: string | null
       source: string
     }>
   } | null
@@ -2428,7 +2420,7 @@ export type ListLibraryElementsQuery = {
     qname: string
     namespace: string | null
     name: string
-    classification: string | null
+    trait: string | null
     balanceType: string
     periodType: string
     isAbstract: boolean
@@ -2454,7 +2446,7 @@ export type SearchLibraryElementsQuery = {
     qname: string
     namespace: string | null
     name: string
-    classification: string | null
+    trait: string | null
     balanceType: string
     periodType: string
     isAbstract: boolean
@@ -2479,7 +2471,7 @@ export type GetLibraryElementQuery = {
     qname: string
     namespace: string | null
     name: string
-    classification: string | null
+    trait: string | null
     balanceType: string
     periodType: string
     isAbstract: boolean
@@ -3173,7 +3165,7 @@ export const GetLedgerAccountRollupsDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'reportingElementId' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'reportingName' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'reportingQname' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'total' } },
                       {
@@ -3228,7 +3220,7 @@ export const GetLedgerAccountTreeDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'code' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'accountType' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'depth' } },
@@ -3242,7 +3234,7 @@ export const GetLedgerAccountTreeDocument = {
                             { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                             { kind: 'Field', name: { kind: 'Name', value: 'code' } },
                             { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                            { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                             { kind: 'Field', name: { kind: 'Name', value: 'accountType' } },
                             { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                             { kind: 'Field', name: { kind: 'Name', value: 'depth' } },
@@ -3256,10 +3248,7 @@ export const GetLedgerAccountTreeDocument = {
                                   { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'code' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                                  {
-                                    kind: 'Field',
-                                    name: { kind: 'Name', value: 'classification' },
-                                  },
+                                  { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'accountType' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'depth' } },
@@ -3273,10 +3262,7 @@ export const GetLedgerAccountTreeDocument = {
                                         { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                                         { kind: 'Field', name: { kind: 'Name', value: 'code' } },
                                         { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                                        {
-                                          kind: 'Field',
-                                          name: { kind: 'Name', value: 'classification' },
-                                        },
+                                        { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                                         {
                                           kind: 'Field',
                                           name: { kind: 'Name', value: 'accountType' },
@@ -3388,7 +3374,6 @@ export const ListLedgerAccountsDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'code' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'name' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'description' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'subClassification' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'parentId' } },
@@ -3576,7 +3561,6 @@ export const ListLedgerElementsDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'description' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'qname' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'subClassification' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'periodType' } },
@@ -4109,7 +4093,7 @@ export const GetLedgerMappedTrialBalanceDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'reportingElementId' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'qname' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'reportingName' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'totalDebits' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'totalCredits' } },
@@ -4859,7 +4843,7 @@ export const GetLedgerStatementDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'elementId' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'elementQname' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'elementName' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'values' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'isSubtotal' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'depth' } },
@@ -5303,7 +5287,7 @@ export const GetLedgerTrialBalanceDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'accountId' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'accountCode' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'accountName' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'accountType' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'totalDebits' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'totalCredits' } },
@@ -5352,7 +5336,7 @@ export const ListLedgerUnmappedElementsDocument = {
                 { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'code' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'externalSource' } },
                 {
@@ -5533,7 +5517,7 @@ export const GetLibraryElementArcsDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'qname' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'source' } },
                     ],
                   },
@@ -5636,7 +5620,7 @@ export const GetLibraryElementEquivalentsDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'qname' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'source' } },
                     ],
                   },
@@ -5650,7 +5634,7 @@ export const GetLibraryElementEquivalentsDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'qname' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'source' } },
                     ],
                   },
@@ -5806,7 +5790,7 @@ export const ListLibraryElementsDocument = {
                 { kind: 'Field', name: { kind: 'Name', value: 'qname' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'periodType' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'isAbstract' } },
@@ -5940,7 +5924,7 @@ export const SearchLibraryElementsDocument = {
                 { kind: 'Field', name: { kind: 'Name', value: 'qname' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'periodType' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'isAbstract' } },
@@ -6025,7 +6009,7 @@ export const GetLibraryElementDocument = {
                 { kind: 'Field', name: { kind: 'Name', value: 'qname' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'classification' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'trait' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'balanceType' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'periodType' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'isAbstract' } },

--- a/clients/graphql/queries/ledger/accountRollups.ts
+++ b/clients/graphql/queries/ledger/accountRollups.ts
@@ -17,7 +17,7 @@ export const GET_ACCOUNT_ROLLUPS = gql`
         reportingElementId
         reportingName
         reportingQname
-        classification
+        trait
         balanceType
         total
         accounts {

--- a/clients/graphql/queries/ledger/accountTree.ts
+++ b/clients/graphql/queries/ledger/accountTree.ts
@@ -18,7 +18,7 @@ export const GET_ACCOUNT_TREE = gql`
         id
         code
         name
-        classification
+        trait
         accountType
         balanceType
         depth
@@ -27,7 +27,7 @@ export const GET_ACCOUNT_TREE = gql`
           id
           code
           name
-          classification
+          trait
           accountType
           balanceType
           depth
@@ -36,7 +36,7 @@ export const GET_ACCOUNT_TREE = gql`
             id
             code
             name
-            classification
+            trait
             accountType
             balanceType
             depth
@@ -45,7 +45,7 @@ export const GET_ACCOUNT_TREE = gql`
               id
               code
               name
-              classification
+              trait
               accountType
               balanceType
               depth

--- a/clients/graphql/queries/ledger/accounts.ts
+++ b/clients/graphql/queries/ledger/accounts.ts
@@ -20,7 +20,6 @@ export const LIST_ACCOUNTS = gql`
         code
         name
         description
-        classification
         subClassification
         balanceType
         parentId

--- a/clients/graphql/queries/ledger/elements.ts
+++ b/clients/graphql/queries/ledger/elements.ts
@@ -29,7 +29,6 @@ export const LIST_ELEMENTS = gql`
         description
         qname
         namespace
-        classification
         subClassification
         balanceType
         periodType

--- a/clients/graphql/queries/ledger/mappedTrialBalance.ts
+++ b/clients/graphql/queries/ledger/mappedTrialBalance.ts
@@ -16,7 +16,7 @@ export const GET_MAPPED_TRIAL_BALANCE = gql`
         reportingElementId
         qname
         reportingName
-        classification
+        trait
         balanceType
         totalDebits
         totalCredits

--- a/clients/graphql/queries/ledger/statement.ts
+++ b/clients/graphql/queries/ledger/statement.ts
@@ -25,7 +25,7 @@ export const GET_STATEMENT = gql`
         elementId
         elementQname
         elementName
-        classification
+        trait
         values
         isSubtotal
         depth

--- a/clients/graphql/queries/ledger/trialBalance.ts
+++ b/clients/graphql/queries/ledger/trialBalance.ts
@@ -15,7 +15,7 @@ export const GET_TRIAL_BALANCE = gql`
         accountId
         accountCode
         accountName
-        classification
+        trait
         accountType
         totalDebits
         totalCredits

--- a/clients/graphql/queries/ledger/unmappedElements.ts
+++ b/clients/graphql/queries/ledger/unmappedElements.ts
@@ -13,7 +13,7 @@ export const LIST_UNMAPPED_ELEMENTS = gql`
       id
       code
       name
-      classification
+      trait
       balanceType
       externalSource
       suggestedTargets {

--- a/clients/graphql/queries/library/arcs.ts
+++ b/clients/graphql/queries/library/arcs.ts
@@ -59,7 +59,7 @@ export const GET_LIBRARY_ELEMENT_ARCS = gql`
         id
         qname
         name
-        classification
+        trait
         source
       }
     }
@@ -92,14 +92,14 @@ export const GET_LIBRARY_ELEMENT_EQUIVALENTS = gql`
         id
         qname
         name
-        classification
+        trait
         source
       }
       equivalents {
         id
         qname
         name
-        classification
+        trait
         source
       }
     }

--- a/clients/graphql/queries/library/elements.ts
+++ b/clients/graphql/queries/library/elements.ts
@@ -42,7 +42,7 @@ export const LIST_LIBRARY_ELEMENTS = gql`
       qname
       namespace
       name
-      classification
+      trait
       balanceType
       periodType
       isAbstract
@@ -76,7 +76,7 @@ export const SEARCH_LIBRARY_ELEMENTS = gql`
       qname
       namespace
       name
-      classification
+      trait
       balanceType
       periodType
       isAbstract
@@ -110,7 +110,7 @@ export const GET_LIBRARY_ELEMENT = gql`
       qname
       namespace
       name
-      classification
+      trait
       balanceType
       periodType
       isAbstract

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -1430,9 +1430,15 @@ export type CreateEventBlockRequest = {
     /**
      * Event Category
      *
-     * REA economic classification. One of: sales, purchase, financing, payroll, treasury, adjustment, recognition, other.
+     * REA classification. Economic categories (sales, purchase, financing, payroll, treasury, adjustment, recognition, other) require event_class='economic'. Support categories (control, approval, reconciliation, inquiry) require event_class='support'. The DB CHECK rejects mismatched pairings.
      */
-    event_category: 'sales' | 'purchase' | 'financing' | 'payroll' | 'treasury' | 'adjustment' | 'recognition' | 'other';
+    event_category: 'sales' | 'purchase' | 'financing' | 'payroll' | 'treasury' | 'adjustment' | 'recognition' | 'other' | 'control' | 'approval' | 'reconciliation' | 'inquiry';
+    /**
+     * Event Class
+     *
+     * REA event class. 'economic' events change resources and drive GL postings; 'support' events are audit-trail / value-chain primitives (typically captured with apply_handlers=False).
+     */
+    event_class?: 'economic' | 'support';
     /**
      * Agent Id
      *
@@ -1509,6 +1515,18 @@ export type CreateEventBlockRequest = {
      * Dimension Ids
      */
     dimension_ids?: Array<string>;
+    /**
+     * Obligated By Event Id
+     *
+     * Forward-materialization link: the event that scheduled or obligated this one (e.g. depreciation entries point at the asset_acquired event).
+     */
+    obligated_by_event_id?: string | null;
+    /**
+     * Discharges Event Id
+     *
+     * Settlement link: the obligation this event discharges (e.g. cash_received pointing at the originating sale_invoiced).
+     */
+    discharges_event_id?: string | null;
     /**
      * Apply Handlers
      *
@@ -3113,9 +3131,9 @@ export type ElementUpdatePatch = {
      */
     description?: string | null;
     /**
-     * Classification
+     * Trait
      */
-    classification?: string | null;
+    trait?: string | null;
     /**
      * Balance Type
      */
@@ -3264,7 +3282,7 @@ export type ErrorResponse = {
 /**
  * EvaluateRulesRequest
  *
- * Request body for the ``evaluate-rules`` operation (Phase delta.3).
+ * Request body for the ``evaluate-rules`` operation.
  *
  * Runs every rule scoped to ``structure_id`` (plus element/association-
  * scoped rules for the structure's atoms), binds ``$Variable`` references
@@ -3283,7 +3301,7 @@ export type EvaluateRulesRequest = {
     /**
      * Fact Set Id
      *
-     * Optional FactSet id to stamp on each VerificationResult row. Allows results to be scoped to a specific period run when the FactSet table is populated (Phase zeta expand pass).
+     * Optional FactSet id to stamp on each VerificationResult row. Allows results to be scoped to a specific period run once write paths populate the FactSet table on every run.
      */
     fact_set_id?: string | null;
     /**
@@ -7174,11 +7192,11 @@ export type TaxonomyBlockElementRequest = {
      */
     name: string;
     /**
-     * Classification
+     * Trait
      *
      * FASB metamodel trait for the element. Required for ``chart_of_accounts`` blocks; optional for ``custom_ontology``.
      */
-    classification?: string | null;
+    trait?: string | null;
     /**
      * Balance Type
      *
@@ -7730,7 +7748,7 @@ export type UpdateEventBlockRequest = {
     /**
      * Transition To
      *
-     * Status transition. Valid moves depend on current status: captured → committed | voided; classified → committed | pending | fulfilled | voided; committed → pending | fulfilled | voided; pending → fulfilled | voided. Terminal states (fulfilled, voided, superseded) accept no further transitions. Note: classified and fulfilled are usually set by handlers, not by callers, but the transition is allowed for corrections.
+     * Status transition. Valid moves depend on current status: captured → committed | voided | superseded; classified → committed | pending | fulfilled | voided | superseded; committed → pending | fulfilled | voided | superseded; pending → fulfilled | voided | superseded. Terminal states (fulfilled, voided, superseded) accept no further transitions. Note: classified and fulfilled are usually set by handlers, not by callers, but the transition is allowed for corrections.
      */
     transition_to?: 'committed' | 'pending' | 'fulfilled' | 'voided' | 'superseded' | null;
     /**
@@ -7755,6 +7773,18 @@ export type UpdateEventBlockRequest = {
     metadata_patch?: {
         [key: string]: unknown;
     };
+    /**
+     * Obligated By Event Id
+     *
+     * Set/update the forward-materialization link.
+     */
+    obligated_by_event_id?: string | null;
+    /**
+     * Discharges Event Id
+     *
+     * Set/update the settlement link.
+     */
+    discharges_event_id?: string | null;
 };
 
 /**
@@ -8093,8 +8123,8 @@ export type UpdateSecurityOperation = {
  *
  * Top-level fields (name / description / version) apply to the taxonomy
  * row itself. The delta lists mutate atoms incrementally — the validator
- * (Phase 2.3) re-runs the seven-phase check across the projected post-
- * update state before anything commits.
+ * re-runs every create-time check across the projected post-update
+ * state before anything commits.
  */
 export type UpdateTaxonomyBlockRequest = {
     /**


### PR DESCRIPTION
## Summary

This PR performs a systematic rename of `classification` to `trait` across all GraphQL queries, generated types, and SDK type definitions to align with updated backend schema terminology. The change touches 12 files spanning the GraphQL client layer (queries + generated types) and the SDK type definitions.

## Changes

### GraphQL Queries (Ledger)
- **accountRollups, accountTree, mappedTrialBalance, statement, trialBalance, unmappedElements**: Updated field references from `classification` to `trait` in query selections.
- **accounts, elements**: Removed `classification` field from query selections (now superseded by `trait`).

### GraphQL Queries (Library)
- **arcs, elements**: Renamed `classification` → `trait` in query fragments and selections.

### Generated Types & SDK
- **`graphql.ts`** (generated): Reflects the schema-level rename — all TypeScript types and interfaces now reference `trait` instead of `classification`. Net reduction in lines suggests some type consolidation or simplification occurred alongside the rename.
- **`sdk/types.gen.ts`**: Updated SDK type definitions to use `trait`, with expanded type coverage (+52 lines net), indicating new or broadened type definitions were introduced alongside the rename.

## Breaking Changes

⚠️ **Yes — this is a breaking change for consumers of these types and queries.**

- Any component or utility referencing `classification` on account, element, arc, or rollup objects will need to be updated to use `trait`.
- Downstream consumers of `sdk/types.gen.ts` that destructure or reference `classification` will break at compile time.
- If any runtime code (e.g., mapping functions, table column definitions, filters) references the string `"classification"` as a key, those will fail silently at runtime rather than at compile time — reviewers should grep broadly.

## Testing Notes

1. **Full-text search**: Grep the entire codebase for any remaining references to `classification` (including string literals, object keys, and test fixtures) to ensure nothing was missed.
2. **GraphQL validation**: Confirm queries execute successfully against the updated backend schema — run the GraphQL codegen (`graphql-codegen`) to verify the generated output matches what's committed.
3. **Type checking**: Run `tsc --noEmit` across the project to catch any compile-time breakage from the rename.
4. **Functional smoke tests**:
   - Verify account tree rendering (uses `accountTree` query).
   - Verify trial balance and mapped trial balance views.
   - Verify statement views.
   - Verify library arcs and elements listings.
   - Verify account rollup displays.
   - Verify unmapped elements view.
5. **SDK consumers**: If the SDK is published or consumed by other packages, ensure downstream consumers are aware of the type rename.

## Browser Compatibility

No browser compatibility concerns — this change is purely a data-layer rename affecting GraphQL queries and TypeScript types with no DOM, CSS, or browser API implications.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/update-event-block`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>