### PR TITLE
feat: add ruleTarget and ruleVariables to information block & report package queries

### DIFF
--- a/clients/graphql/generated/graphql.ts
+++ b/clients/graphql/generated/graphql.ts
@@ -2785,6 +2785,8 @@ export type GetInformationBlockQuery = {
       ruleMessage: string | null
       ruleSeverity: string
       ruleOrigin: string
+      ruleTarget: { targetKind: string; targetRefId: string } | null
+      ruleVariables: Array<{ variableName: string; variableQname: string }>
     }>
     factSet: {
       id: string
@@ -2893,6 +2895,8 @@ export type ListInformationBlocksQuery = {
       ruleMessage: string | null
       ruleSeverity: string
       ruleOrigin: string
+      ruleTarget: { targetKind: string; targetRefId: string } | null
+      ruleVariables: Array<{ variableName: string; variableQname: string }>
     }>
     factSet: {
       id: string
@@ -3240,6 +3244,8 @@ export type GetLedgerReportPackageQuery = {
           ruleMessage: string | null
           ruleSeverity: string
           ruleOrigin: string
+          ruleTarget: { targetKind: string; targetRefId: string } | null
+          ruleVariables: Array<{ variableName: string; variableQname: string }>
         }>
         factSet: {
           id: string
@@ -5518,6 +5524,28 @@ export const GetInformationBlockDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'ruleMessage' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'ruleSeverity' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'ruleOrigin' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'ruleTarget' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'targetKind' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'targetRefId' } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'ruleVariables' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'variableName' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'variableQname' } },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },
@@ -5783,6 +5811,28 @@ export const ListInformationBlocksDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'ruleMessage' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'ruleSeverity' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'ruleOrigin' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'ruleTarget' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'targetKind' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'targetRefId' } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'ruleVariables' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'variableName' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'variableQname' } },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },
@@ -6701,6 +6751,40 @@ export const GetLedgerReportPackageDocument = {
                                   { kind: 'Field', name: { kind: 'Name', value: 'ruleMessage' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'ruleSeverity' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'ruleOrigin' } },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'ruleTarget' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'targetKind' },
+                                        },
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'targetRefId' },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'ruleVariables' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'variableName' },
+                                        },
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'variableQname' },
+                                        },
+                                      ],
+                                    },
+                                  },
                                 ],
                               },
                             },

--- a/clients/graphql/queries/ledger/informationBlock.ts
+++ b/clients/graphql/queries/ledger/informationBlock.ts
@@ -66,6 +66,14 @@ export const GET_INFORMATION_BLOCK = gql`
         ruleMessage
         ruleSeverity
         ruleOrigin
+        ruleTarget {
+          targetKind
+          targetRefId
+        }
+        ruleVariables {
+          variableName
+          variableQname
+        }
       }
       factSet {
         id
@@ -182,6 +190,14 @@ export const LIST_INFORMATION_BLOCKS = gql`
         ruleMessage
         ruleSeverity
         ruleOrigin
+        ruleTarget {
+          targetKind
+          targetRefId
+        }
+        ruleVariables {
+          variableName
+          variableQname
+        }
       }
       factSet {
         id

--- a/clients/graphql/queries/ledger/reportPackage.ts
+++ b/clients/graphql/queries/ledger/reportPackage.ts
@@ -95,6 +95,14 @@ export const GET_REPORT_PACKAGE = gql`
             ruleMessage
             ruleSeverity
             ruleOrigin
+            ruleTarget {
+              targetKind
+              targetRefId
+            }
+            ruleVariables {
+              variableName
+              variableQname
+            }
           }
           factSet {
             id


### PR DESCRIPTION
## Summary

This PR extends the GraphQL query layer to include `ruleTarget` and `ruleVariables` fields on information block and report package queries. These new fields enable the frontend to access rule-related metadata associated with information blocks, which is necessary for upcoming rule-based reporting features.

## Changes

### GraphQL Schema & Queries
- **`informationBlock.ts`**: Added `ruleTarget` and `ruleVariables` fields (along with their nested sub-fields) to the information block query fragment/query definition. This accounts for the bulk of the new lines (~16 lines of query structure).
- **`reportPackage.ts`**: Extended the report package query to also surface `ruleTarget` and `ruleVariables` through its nested information block references (~8 lines).
- **`generated/graphql.ts`**: Updated auto-generated TypeScript types and query documents to reflect the schema additions (~84 lines of generated code covering new types, interfaces, and query document updates).

## Key Details

- **No UI/UX changes**: This PR is purely a data-layer enhancement. No visual or interaction changes are introduced — the new fields are being wired up for consumption by future UI work.
- **Additive only**: New fields are added to existing queries; no existing fields are modified or removed.

## Breaking Changes

None. This is a strictly additive change. Existing queries continue to function as before, with additional optional fields now available in the response types.

## Testing Notes for Reviewers

1. **Type correctness**: Verify that the generated types in `graphql.ts` correctly reflect the `ruleTarget` and `ruleVariables` structures, including any nested objects or enums.
2. **Query validation**: Confirm the updated queries are valid against the current GraphQL schema by running codegen (`npm run codegen` or equivalent) and ensuring no schema errors are reported.
3. **No runtime regressions**: Verify that pages/components consuming the `informationBlock` and `reportPackage` queries still render correctly — the new fields should be `null`/`undefined` gracefully when not populated by the backend.
4. **Check generated file consistency**: Ensure `generated/graphql.ts` was regenerated (not hand-edited) and matches the source query definitions.

## Browser Compatibility

No browser compatibility concerns — changes are limited to GraphQL query definitions and TypeScript types, with no runtime browser-specific code affected.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/report-package-query`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>