### PR TITLE
feat(ledger): surface fact provenance on the IB envelope

### DIFF
--- a/clients/graphql/generated/graphql.ts
+++ b/clients/graphql/generated/graphql.ts
@@ -553,6 +553,8 @@ export type InformationBlockFactSet = {
   id: Scalars['String']['output']
   periodEnd: Scalars['Date']['output']
   periodStart: Maybe<Scalars['Date']['output']>
+  /** Typed ``FactProvenance`` descriptor (discriminated on ``origin``: pivot | schedule | derived | asserted) recording how this FactSet's facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null for pre-feature historical FactSets. */
+  provenance: Maybe<Scalars['JSON']['output']>
   /** Back-pointer to the ``reports`` table while ``report_id`` still lives on facts. Drops out once the retirement migration lands. */
   reportId: Maybe<Scalars['String']['output']>
   structureId: Maybe<Scalars['String']['output']>
@@ -2846,6 +2848,7 @@ export type GetInformationBlockQuery = {
       factsetType: string
       entityId: string
       reportId: string | null
+      provenance: any | null
     } | null
     verificationResults: Array<{
       id: string
@@ -2972,6 +2975,7 @@ export type ListInformationBlocksQuery = {
       factsetType: string
       entityId: string
       reportId: string | null
+      provenance: any | null
     } | null
     verificationResults: Array<{
       id: string
@@ -3345,6 +3349,7 @@ export type GetLedgerReportPackageQuery = {
           factsetType: string
           entityId: string
           reportId: string | null
+          provenance: any | null
         } | null
         verificationResults: Array<{
           id: string
@@ -5669,6 +5674,7 @@ export const GetInformationBlockDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'factsetType' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'entityId' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'reportId' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'provenance' } },
                     ],
                   },
                 },
@@ -5986,6 +5992,7 @@ export const ListInformationBlocksDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'factsetType' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'entityId' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'reportId' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'provenance' } },
                     ],
                   },
                 },
@@ -7010,6 +7017,7 @@ export const GetLedgerReportPackageDocument = {
                                   { kind: 'Field', name: { kind: 'Name', value: 'factsetType' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'entityId' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'reportId' } },
+                                  { kind: 'Field', name: { kind: 'Name', value: 'provenance' } },
                                 ],
                               },
                             },

--- a/clients/graphql/queries/ledger/informationBlock.ts
+++ b/clients/graphql/queries/ledger/informationBlock.ts
@@ -84,6 +84,7 @@ export const GET_INFORMATION_BLOCK = gql`
         factsetType
         entityId
         reportId
+        provenance
       }
       verificationResults {
         id
@@ -224,6 +225,7 @@ export const LIST_INFORMATION_BLOCKS = gql`
         factsetType
         entityId
         reportId
+        provenance
       }
       verificationResults {
         id

--- a/clients/graphql/queries/ledger/reportPackage.ts
+++ b/clients/graphql/queries/ledger/reportPackage.ts
@@ -113,6 +113,7 @@ export const GET_REPORT_PACKAGE = gql`
             factsetType
             entityId
             reportId
+            provenance
           }
           verificationResults {
             id

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -4299,6 +4299,14 @@ export type FactSetLite = {
      * Back-pointer to the ``reports`` table while ``report_id`` still lives on facts. Drops out once the retirement migration lands.
      */
     report_id?: string | null;
+    /**
+     * Provenance
+     *
+     * Typed ``FactProvenance`` descriptor (discriminated on ``origin``: pivot | schedule | derived | asserted) recording how this FactSet's facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null for pre-feature historical FactSets.
+     */
+    provenance?: {
+        [key: string]: unknown;
+    } | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR adds fact provenance metadata to the Information Block (IB) envelope by extending the GraphQL queries and generated types. When consumers retrieve information blocks—either directly or via report packages—they will now receive provenance details alongside each fact, enabling downstream traceability of where facts originated.

## Changes

### GraphQL Schema & Queries
- **`informationBlock.ts`**: Added provenance-related fields to the Information Block query, ensuring fact provenance data is requested when fetching IB envelopes.
- **`reportPackage.ts`**: Extended the report package query to include the new fact provenance field, maintaining consistency across entry points that surface IB data.

### Generated Types
- **`graphql.ts`** (generated): Updated auto-generated GraphQL types to reflect the new provenance fields on fact-level types.
- **`sdk/types.gen.ts`**: Extended SDK type definitions with corresponding provenance properties, keeping the SDK contract aligned with the GraphQL layer.

## Key UI/UX Improvements

- This is a **data-layer change only**—no visual or interaction changes are introduced in this PR. However, it unblocks future UI work that can display fact provenance (e.g., source attribution, audit trails) on information block views.

## Breaking Changes

- **None expected.** The changes are purely additive—new optional fields on existing types. Existing consumers that do not reference the new provenance fields will continue to function without modification.
- Consumers using code-generated GraphQL clients should regenerate their types to pick up the new fields if they wish to access provenance data.

## Testing Notes for Reviewers

1. **Type correctness**: Verify that `graphql.ts` and `types.gen.ts` are consistent with each other and that the new provenance fields are correctly typed (nullable/optional as appropriate).
2. **Query validation**: Confirm the updated queries in `informationBlock.ts` and `reportPackage.ts` align with the backend schema—run the queries against a dev/staging GraphQL endpoint to ensure no schema mismatch errors.
3. **Regression check**: Fetch an information block and a report package via the existing UI or API calls and confirm that responses still deserialize correctly and existing fields are unaffected.
4. **Provenance populated**: If test data with provenance exists, verify the new fields are returned and correctly shaped in the response payload.

## Browser Compatibility Considerations

- No browser-specific concerns—this PR modifies only GraphQL query definitions and TypeScript type declarations, which are transpiled/bundled at build time and have no runtime browser dependency.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/fact-provenance`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>