### PR TITLE
feat(library): add structures query and tree fields on taxonomy arcs

### DIFF
--- a/clients/LibraryClient.ts
+++ b/clients/LibraryClient.ts
@@ -37,6 +37,7 @@ import {
   GetLibraryElementEquivalentsDocument,
   GetLibraryTaxonomyDocument,
   ListLibraryElementsDocument,
+  ListLibraryStructuresDocument,
   ListLibraryTaxonomiesDocument,
   ListLibraryTaxonomyArcsDocument,
   SearchLibraryElementsDocument,
@@ -46,6 +47,7 @@ import {
   type GetLibraryElementQuery,
   type GetLibraryTaxonomyQuery,
   type ListLibraryElementsQuery,
+  type ListLibraryStructuresQuery,
   type ListLibraryTaxonomiesQuery,
   type ListLibraryTaxonomyArcsQuery,
   type SearchLibraryElementsQuery,
@@ -67,6 +69,7 @@ export type LibraryLabel = LibraryElementDetail['labels'][number]
 export type LibraryReference = LibraryElementDetail['references'][number]
 
 export type LibraryArc = ListLibraryTaxonomyArcsQuery['libraryTaxonomyArcs'][number]
+export type LibraryStructure = ListLibraryStructuresQuery['libraryStructures'][number]
 export type LibraryElementArc = GetLibraryElementArcsQuery['libraryElementArcs'][number]
 export type LibraryElementClassification =
   GetLibraryElementClassificationsQuery['libraryElementClassifications'][number]
@@ -99,6 +102,8 @@ export interface SearchLibraryElementsOptions {
 
 export interface ListLibraryTaxonomyArcsOptions {
   associationType?: string
+  /** Scope to a single structure (one presentation/calculation hierarchy). */
+  structureId?: string
   limit?: number
   offset?: number
 }
@@ -106,6 +111,12 @@ export interface ListLibraryTaxonomyArcsOptions {
 export interface ListLibraryTaxonomyArcsResult {
   arcs: LibraryArc[]
   count: number
+}
+
+export interface ListLibraryStructuresOptions {
+  taxonomyId?: string
+  /** Filter to one statement kind (balance_sheet | income_statement | …). */
+  blockType?: string
 }
 
 export interface GetLibraryElementIdentifier {
@@ -276,6 +287,7 @@ export class LibraryClient {
       {
         taxonomyId,
         associationType: options?.associationType ?? null,
+        structureId: options?.structureId ?? null,
         limit: options?.limit ?? 200,
         offset: options?.offset ?? 0,
       },
@@ -284,6 +296,32 @@ export class LibraryClient {
         arcs: data.libraryTaxonomyArcs,
         count: data.libraryTaxonomyArcCount,
       })
+    )
+  }
+
+  // ── Structures ───────────────────────────────────────────────────────
+
+  /**
+   * List the structures (extended link roles) a taxonomy contributes —
+   * the named presentation/calculation hierarchies (BS-classified,
+   * IS-multistep, the calc DAG roots, …). Pair a structure's `id` with
+   * `listLibraryTaxonomyArcs({ structureId })` to load just that
+   * hierarchy's arcs — the hierarchy view uses this to scope a tree to
+   * one role at a time.
+   */
+  async listLibraryStructures(
+    graphId: string,
+    options?: ListLibraryStructuresOptions
+  ): Promise<LibraryStructure[]> {
+    return this.gqlQuery(
+      graphId,
+      ListLibraryStructuresDocument,
+      {
+        taxonomyId: options?.taxonomyId ?? null,
+        blockType: options?.blockType ?? null,
+      },
+      'List library structures',
+      (data) => data.libraryStructures
     )
   }
 

--- a/clients/graphql/generated/graphql.ts
+++ b/clients/graphql/generated/graphql.ts
@@ -932,15 +932,21 @@ export type LibraryAssociation = {
   /** presentation | calculation | mapping | equivalence | general-special | essence-alias */
   associationType: Scalars['String']['output']
   fromElementId: Scalars['String']['output']
+  fromElementIsAbstract: Maybe<Scalars['Boolean']['output']>
   fromElementName: Maybe<Scalars['String']['output']>
   fromElementQname: Maybe<Scalars['String']['output']>
+  /** Primary elementsOfFinancialStatements trait (for node coloring) */
+  fromElementTrait: Maybe<Scalars['String']['output']>
   id: Scalars['String']['output']
   orderValue: Maybe<Scalars['Float']['output']>
   structureId: Scalars['String']['output']
   structureName: Maybe<Scalars['String']['output']>
   toElementId: Scalars['String']['output']
+  toElementIsAbstract: Maybe<Scalars['Boolean']['output']>
   toElementName: Maybe<Scalars['String']['output']>
   toElementQname: Maybe<Scalars['String']['output']>
+  /** Primary elementsOfFinancialStatements trait (for node coloring) */
+  toElementTrait: Maybe<Scalars['String']['output']>
   weight: Maybe<Scalars['Float']['output']>
 }
 
@@ -3673,6 +3679,7 @@ export type ListLedgerUnmappedElementsQuery = {
 export type ListLibraryTaxonomyArcsQueryVariables = Exact<{
   taxonomyId: Scalars['ID']['input']
   associationType: InputMaybe<Scalars['String']['input']>
+  structureId: InputMaybe<Scalars['ID']['input']>
   limit?: Scalars['Int']['input']
   offset?: Scalars['Int']['input']
 }>
@@ -3686,9 +3693,13 @@ export type ListLibraryTaxonomyArcsQuery = {
     fromElementId: string
     fromElementQname: string | null
     fromElementName: string | null
+    fromElementTrait: string | null
+    fromElementIsAbstract: boolean | null
     toElementId: string
     toElementQname: string | null
     toElementName: string | null
+    toElementTrait: string | null
+    toElementIsAbstract: boolean | null
     associationType: string
     arcrole: string | null
     orderValue: number | null
@@ -3826,6 +3837,37 @@ export type GetLibraryElementQuery = {
     parentId: string | null
     labels: Array<{ role: string; language: string; text: string }>
     references: Array<{ refType: string | null; citation: string; uri: string | null }>
+  } | null
+}
+
+export type ListLibraryStructuresQueryVariables = Exact<{
+  taxonomyId: InputMaybe<Scalars['ID']['input']>
+  blockType: InputMaybe<Scalars['String']['input']>
+}>
+
+export type ListLibraryStructuresQuery = {
+  libraryStructures: Array<{
+    id: string
+    name: string
+    blockType: string
+    taxonomyId: string
+    roleUri: string | null
+    isActive: boolean
+  }>
+}
+
+export type GetLibraryStructureQueryVariables = Exact<{
+  id: Scalars['ID']['input']
+}>
+
+export type GetLibraryStructureQuery = {
+  libraryStructure: {
+    id: string
+    name: string
+    blockType: string
+    taxonomyId: string
+    roleUri: string | null
+    isActive: boolean
   } | null
 }
 
@@ -7943,6 +7985,11 @@ export const ListLibraryTaxonomyArcsDocument = {
         },
         {
           kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'structureId' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'ID' } },
+        },
+        {
+          kind: 'VariableDefinition',
           variable: { kind: 'Variable', name: { kind: 'Name', value: 'limit' } },
           type: {
             kind: 'NonNullType',
@@ -7972,6 +8019,16 @@ export const ListLibraryTaxonomyArcsDocument = {
                 name: { kind: 'Name', value: 'taxonomyId' },
                 value: { kind: 'Variable', name: { kind: 'Name', value: 'taxonomyId' } },
               },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'associationType' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'associationType' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'structureId' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'structureId' } },
+              },
             ],
           },
           {
@@ -7987,6 +8044,11 @@ export const ListLibraryTaxonomyArcsDocument = {
                 kind: 'Argument',
                 name: { kind: 'Name', value: 'associationType' },
                 value: { kind: 'Variable', name: { kind: 'Name', value: 'associationType' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'structureId' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'structureId' } },
               },
               {
                 kind: 'Argument',
@@ -8008,9 +8070,13 @@ export const ListLibraryTaxonomyArcsDocument = {
                 { kind: 'Field', name: { kind: 'Name', value: 'fromElementId' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'fromElementQname' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'fromElementName' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'fromElementTrait' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'fromElementIsAbstract' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'toElementId' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'toElementQname' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'toElementName' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'toElementTrait' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'toElementIsAbstract' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'associationType' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'arcrole' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'orderValue' } },
@@ -8607,6 +8673,107 @@ export const GetLibraryElementDocument = {
     },
   ],
 } as unknown as DocumentNode<GetLibraryElementQuery, GetLibraryElementQueryVariables>
+export const ListLibraryStructuresDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'ListLibraryStructures' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'taxonomyId' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'ID' } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'blockType' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'libraryStructures' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'taxonomyId' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'taxonomyId' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'blockType' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'blockType' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'blockType' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'taxonomyId' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'roleUri' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'isActive' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListLibraryStructuresQuery, ListLibraryStructuresQueryVariables>
+export const GetLibraryStructureDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'GetLibraryStructure' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'ID' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'libraryStructure' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'id' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'blockType' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'taxonomyId' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'roleUri' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'isActive' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetLibraryStructureQuery, GetLibraryStructureQueryVariables>
 export const ListLibraryTaxonomiesDocument = {
   kind: 'Document',
   definitions: [

--- a/clients/graphql/queries/library/arcs.ts
+++ b/clients/graphql/queries/library/arcs.ts
@@ -10,13 +10,19 @@ export const LIST_LIBRARY_TAXONOMY_ARCS = gql`
   query ListLibraryTaxonomyArcs(
     $taxonomyId: ID!
     $associationType: String
+    $structureId: ID
     $limit: Int! = 200
     $offset: Int! = 0
   ) {
-    libraryTaxonomyArcCount(taxonomyId: $taxonomyId)
+    libraryTaxonomyArcCount(
+      taxonomyId: $taxonomyId
+      associationType: $associationType
+      structureId: $structureId
+    )
     libraryTaxonomyArcs(
       taxonomyId: $taxonomyId
       associationType: $associationType
+      structureId: $structureId
       limit: $limit
       offset: $offset
     ) {
@@ -26,9 +32,13 @@ export const LIST_LIBRARY_TAXONOMY_ARCS = gql`
       fromElementId
       fromElementQname
       fromElementName
+      fromElementTrait
+      fromElementIsAbstract
       toElementId
       toElementQname
       toElementName
+      toElementTrait
+      toElementIsAbstract
       associationType
       arcrole
       orderValue

--- a/clients/graphql/queries/library/structures.ts
+++ b/clients/graphql/queries/library/structures.ts
@@ -1,0 +1,44 @@
+import { gql } from 'graphql-request'
+
+/**
+ * List the structures (extended link roles) contributed by a taxonomy —
+ * the named presentation/calculation hierarchies (BS-classified,
+ * IS-multistep, CashFlow, the calc DAG roots, etc). Pair a structure's
+ * ``id`` with ``listLibraryTaxonomyArcs`` + a ``structureId`` filter to
+ * load just that hierarchy's arcs — this is how the hierarchy view scopes
+ * a tree to one role at a time.
+ *
+ * Pass ``taxonomyId`` to scope to a single taxonomy; pass ``blockType``
+ * to filter to one statement kind (balance_sheet, income_statement,
+ * cash_flow_statement, …).
+ */
+export const LIST_LIBRARY_STRUCTURES = gql`
+  query ListLibraryStructures($taxonomyId: ID, $blockType: String) {
+    libraryStructures(taxonomyId: $taxonomyId, blockType: $blockType) {
+      id
+      name
+      blockType
+      taxonomyId
+      roleUri
+      isActive
+    }
+  }
+`
+
+/**
+ * Fetch one structure by id. Returns null when the id doesn't resolve.
+ * Metadata only — pair with ``listLibraryTaxonomyArcs`` + a ``structureId``
+ * filter to load the structure's arcs.
+ */
+export const GET_LIBRARY_STRUCTURE = gql`
+  query GetLibraryStructure($id: ID!) {
+    libraryStructure(id: $id) {
+      id
+      name
+      blockType
+      taxonomyId
+      roleUri
+      isActive
+    }
+  }
+`


### PR DESCRIPTION
## Summary

This PR introduces support for the library hierarchy view by adding a new `structures` GraphQL query and extending the existing taxonomy arcs query with tree-related fields. These changes lay the groundwork for rendering hierarchical/tree views of library content.

### Changes

#### New: Structures Query (`clients/graphql/queries/library/structures.ts`)
- Added a new GraphQL query file for fetching library structures
- This query enables retrieval of structural/hierarchical data needed to power the library hierarchy view

#### Modified: Taxonomy Arcs Query (`clients/graphql/queries/library/arcs.ts`)
- Extended the existing arcs query with tree-specific fields
- These additional fields provide the parent-child relationship data necessary for rendering tree structures in the UI

#### Modified: Library Client (`clients/LibraryClient.ts`)
- Added client-side method(s) to execute the new structures query
- Integrated the new query into the existing `LibraryClient` API surface

#### Auto-generated: GraphQL Types (`clients/graphql/generated/graphql.ts`)
- Updated generated TypeScript types reflecting the new query and extended arc fields (+167 lines of generated type definitions)

## Key UI/UX Improvements

- **Hierarchy View Foundation**: This is the data-layer prerequisite for displaying library content in a tree/hierarchy format, enabling users to navigate taxonomies and structures more intuitively
- No direct UI changes in this PR — this is a data/query layer addition

## Breaking Changes

None. This PR is purely additive:
- New query file added
- Existing arcs query extended (fields added, none removed)
- New client method(s) added without modifying existing signatures

## Testing Notes for Reviewers

1. **Verify GraphQL codegen consistency**: Ensure `clients/graphql/generated/graphql.ts` was regenerated and matches the query/schema changes — run the codegen script locally and confirm no diff
2. **Structures query**: Validate that the new structures query executes correctly against the GraphQL API (check field names, variable types, and response shape)
3. **Arcs query regression**: Confirm that adding tree fields to the arcs query does not break existing consumers — the additional fields should be optional/non-breaking for current usage
4. **Type safety**: Verify that the new TypeScript types are correctly referenced in `LibraryClient.ts` and that no type errors are introduced

## Browser Compatibility Considerations

No browser compatibility concerns — all changes are server-side/data-layer (GraphQL queries and TypeScript client code). No DOM, CSS, or browser API changes are included.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/library-hierarchy-view`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>