### PR TITLE
chore(create-feature): default branch creation to no dep update

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -106,7 +106,7 @@
       "id": "updateDependencies",
       "type": "pickString",
       "description": "Update dependencies after creating branch:",
-      "default": "yes",
+      "default": "no",
       "options": ["yes", "no"]
     },
     {

--- a/bin/create-feature.sh
+++ b/bin/create-feature.sh
@@ -9,7 +9,7 @@ set -e
 BRANCH_TYPE=${1:-feature}
 BRANCH_NAME=${2:-}
 BASE_BRANCH=${3:-main}
-UPDATE_DEPS=${4:-yes}
+UPDATE_DEPS=${4:-no}
 
 # Validate branch type
 if [[ "$BRANCH_TYPE" != "feature" && "$BRANCH_TYPE" != "bugfix" && "$BRANCH_TYPE" != "hotfix" && "$BRANCH_TYPE" != "chore" && "$BRANCH_TYPE" != "refactor" ]]; then
@@ -80,7 +80,9 @@ git push -u origin $FULL_BRANCH
 echo ""
 echo "🎉 Successfully created and checked out $FULL_BRANCH"
 
-# Update dependencies if requested (default: yes)
+# Update dependencies only when explicitly requested (default: no).
+# Pass "yes" as the 4th arg to refresh deps on the new branch; otherwise
+# branch creation leaves the lockfile untouched.
 if [[ "$UPDATE_DEPS" == "yes" ]]; then
   echo ""
   echo "📦 Updating dependencies..."


### PR DESCRIPTION
## What
Flip the `update_deps` default in `bin/create-feature.sh` from `yes` to `no`.

## Why
Branch creation ran `npm update` by default, refreshing the lockfile on every new branch and sweeping unrelated dependency churn into focused branches.

## Change
- `bin/create-feature.sh`: `UPDATE_DEPS=${4:-no}` (was `yes`) + clarified the guard comment

Pass `yes` as the 4th arg to opt into a dependency refresh when intended:
`npm run feature:create -- feature my-branch main yes`

Mirrors the same fix applied across the RoboSystems repos.