### PR TITLE
fix(codegen): strip unknown GraphQL directive locations during introspection

### DIFF
--- a/clients/graphql/generated/graphql.ts
+++ b/clients/graphql/generated/graphql.ts
@@ -670,8 +670,8 @@ export type InformationBlockValidation = {
  * Pass/fail/skip counts for one ``rule_category`` within a block's
  * verification results.
  *
- * Drives the per-category accordions in the Verification Results panel
- * (financial-viewer §7.12). ``category`` is the rule's ``rule_category``
+ * Drives the per-category accordions in the Verification Results panel.
+ * ``category`` is the rule's ``rule_category``
  * (one of the cm:VerificationRule subclasses), resolved by joining each
  * result to its Rule.
  */
@@ -709,7 +709,7 @@ export type InformationBlockVerificationResult = {
  * Server-computed aggregate of a block's ``verification_results``.
  *
  * Overall counts plus a per-``rule_category`` breakdown, so the viewer
- * renders the grouped Verification Results panel (financial-viewer §7.12)
+ * renders the grouped Verification Results panel
  * without a client-side results→rules join. Status closure is
  * ``pass | fail | error | skipped`` (the ``public.verification_results``
  * CHECK); ``total`` is their sum.
@@ -2168,6 +2168,7 @@ export type UnmappedElement = {
   code: Maybe<Scalars['String']['output']>
   externalSource: Maybe<Scalars['String']['output']>
   id: Scalars['String']['output']
+  liquidity: Maybe<Scalars['String']['output']>
   name: Scalars['String']['output']
   suggestedTargets: Array<SuggestedTarget>
   trait: Maybe<Scalars['String']['output']>

--- a/codegen.ts
+++ b/codegen.ts
@@ -1,4 +1,50 @@
 import type { CodegenConfig } from '@graphql-codegen/cli'
+import { DirectiveLocation } from 'graphql'
+
+/**
+ * Sanitize the introspection response before codegen builds the schema.
+ *
+ * The backend runs graphql-core (Python), which tracks newer GraphQL spec
+ * drafts than our graphql-js (16.x). graphql-core advertises `@deprecated`
+ * on the `DIRECTIVE_DEFINITION` location, but graphql-js 16's parser doesn't
+ * recognize that location keyword. graphql-codegen serializes the introspected
+ * schema back to SDL (`directive @deprecated(...) on ... | DIRECTIVE_DEFINITION`)
+ * and re-parses it, which blows up with:
+ *   Syntax Error: Unexpected Name "DIRECTIVE_DEFINITION".
+ *
+ * We strip any directive location our graphql-js doesn't know about from the
+ * introspection result so the SDL round-trip stays valid. Filtering against the
+ * full known set (rather than just DIRECTIVE_DEFINITION) keeps us resilient to
+ * future graphql-core/spec additions.
+ */
+const KNOWN_DIRECTIVE_LOCATIONS = new Set<string>(Object.values(DirectiveLocation))
+
+const sanitizingFetch: typeof fetch = async (input, init) => {
+  const response = await fetch(input, init)
+  const body = await response.json()
+  const directives = body?.data?.__schema?.directives
+  if (Array.isArray(directives)) {
+    for (const directive of directives) {
+      if (!Array.isArray(directive?.locations)) continue
+      const dropped = directive.locations.filter(
+        (loc: string) => !KNOWN_DIRECTIVE_LOCATIONS.has(loc)
+      )
+      if (dropped.length > 0) {
+        directive.locations = directive.locations.filter((loc: string) =>
+          KNOWN_DIRECTIVE_LOCATIONS.has(loc)
+        )
+        console.warn(
+          `[codegen] Stripped unknown directive location(s) from @${directive.name}: ${dropped.join(', ')}`
+        )
+      }
+    }
+  }
+  return new Response(JSON.stringify(body), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: { 'content-type': 'application/json' },
+  })
+}
 
 /**
  * GraphQL Code Generator config.
@@ -29,10 +75,16 @@ import type { CodegenConfig } from '@graphql-codegen/cli'
  * ROBOINVESTOR_ENABLED=true (so the schema mounts at all) AND
  * EXTENSIONS_GRAPHQL_ENABLED=true (the kill switch is on by default).
  */
+const schemaUrl =
+  process.env.GRAPHQL_SCHEMA_URL ||
+  'http://localhost:8000/extensions/kg00000000000000000000/graphql'
+
 const config: CodegenConfig = {
-  schema:
-    process.env.GRAPHQL_SCHEMA_URL ||
-    'http://localhost:8000/extensions/kg00000000000000000000/graphql',
+  schema: {
+    [schemaUrl]: {
+      customFetch: sanitizingFetch,
+    },
+  },
   documents: ['clients/graphql/queries/**/*.ts'],
   generates: {
     'clients/graphql/generated/graphql.ts': {

--- a/sdk/sdk.gen.ts
+++ b/sdk/sdk.gen.ts
@@ -1048,7 +1048,7 @@ export const opChangeTier = <ThrowOnError extends boolean = false>(options: Opti
 /**
  * Change Reporting Style
  *
- * Switches the graph's Reporting Style (Phase 2 of §3.2). Synchronous: validates the target Style has a complete composition in the tenant schema, then updates `graphs.reporting_style_id`. Filed Reports are unaffected; new reports use the new Style. Idempotent on the same id.
+ * Switches the graph's Reporting Style. Synchronous: validates the target Style has a complete composition in the tenant schema, then updates `graphs.reporting_style_id`. Filed Reports are unaffected; new reports use the new Style. Idempotent on the same id.
  *
  * **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
  */
@@ -1414,7 +1414,7 @@ export const opUpdateEntity = <ThrowOnError extends boolean = false>(options: Op
 /**
  * Create Taxonomy Block
  *
- * Create a taxonomy block atomically: one envelope carrying the taxonomy row plus its structures, elements, associations, and rules. Dispatches by `taxonomy_type` — `chart_of_accounts` (declarative tenant CoA) is live; `reporting_extension` / `custom_ontology` / `reporting_standard` land in later sub-phases.
+ * Create a taxonomy block atomically: one envelope carrying the taxonomy row plus its structures, elements, associations, and rules. Dispatches by `taxonomy_type` — `chart_of_accounts` (declarative tenant CoA) is supported; `reporting_extension` / `custom_ontology` / `reporting_standard` are not yet implemented.
  *
  * **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
  */
@@ -1584,7 +1584,7 @@ export const opDeleteInformationBlock = <ThrowOnError extends boolean = false>(o
 /**
  * Evaluate Rules for an Information Block
  *
- * Runs every rule targeting the given structure (plus element- and association-scoped rules for the structure's atoms), binds $Variable references to in-scope facts via qname lookup, writes one VerificationResult row per rule, and returns the results plus a status-keyed summary. Phase delta.3 — decoding mode, 5 patterns (EqualTo, RollUp, RollForward, Exists, CoExists).
+ * Runs every rule targeting the given structure (plus element- and association-scoped rules for the structure's atoms), binds $Variable references to in-scope facts via qname lookup, writes one VerificationResult row per rule, and returns the results plus a status-keyed summary. Decoding mode, 5 patterns (EqualTo, RollUp, RollForward, Exists, CoExists).
  *
  * **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
  */

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -763,7 +763,7 @@ export type CancelSubscriptionRequest = {
 /**
  * ChangeReportingStyleOp
  *
- * Body for the change-reporting-style operation (Phase 2 of §3.2).
+ * Body for the change-reporting-style operation.
  *
  * Switches the graph to a different Reporting Style. The target Style
  * must be a library- or customer-authored Structure with
@@ -980,7 +980,7 @@ export type ClosePeriodResponse = {
     /**
      * Rule Summary
      *
-     * Aggregated rule-eval outcome across every schedule Structure with facts in the closed period — keys: pass/fail/error/skipped. None when no schedules had facts in the period (§3.8 auto-run on close).
+     * Aggregated rule-eval outcome across every schedule Structure with facts in the closed period — keys: pass/fail/error/skipped. None when no schedules had facts in the period (auto-run on close).
      */
     rule_summary?: {
         [key: string]: number;
@@ -6541,7 +6541,7 @@ export type ListSubgraphsResponse = {
     /**
      * Subgraphs Enabled
      *
-     * Whether subgraphs are enabled for this tier (requires LadybugDB Large/XLarge)
+     * Whether subgraphs are enabled for this tier (requires Large/XLarge tier)
      */
     subgraphs_enabled: boolean;
     /**
@@ -10343,18 +10343,17 @@ export type RestoreBackupOp = {
  *
  * Filter-based attribution mechanics for ``block_type='rollforward'``.
  *
- * Implements Tier 2 of the rollforward attribution design
- * (``information-block.md`` §4.5). Each block decomposes one BS
- * source element's period delta into a list of flow concepts via
- * declared :class:`AttributionFilter` predicates. The renderer
- * evaluates the filters against ledger LineItems at envelope-build
- * time, emits one attributed fact per filter per period, and arbitrates
- * any residual against the default change tag (Tier 1 fallback).
+ * Filter-based attribution: each block decomposes one BS source
+ * element's period delta into a list of flow concepts via declared
+ * :class:`AttributionFilter` predicates. The renderer evaluates the
+ * filters against ledger LineItems at envelope-build time, emits one
+ * attributed fact per filter per period, and arbitrates any residual
+ * against the default change tag fallback.
  *
  * Reads directly from the typed ``structures.artifact_mechanics`` JSONB
  * column. ``attribution_filters`` rides as nested JSON; the predicate
- * union widens as new predicate shapes ship (Phase 2 MVP carries only
- * ``line_item_metadata_field``).
+ * union widens as new predicate shapes are added — currently only
+ * ``line_item_metadata_field`` is carried.
  */
 export type RollforwardMechanics = {
     /**
@@ -10376,13 +10375,13 @@ export type RollforwardMechanics = {
     /**
      * Default Change Tag Element Id
      *
-     * Element id of the Tier 1 default change tag — the fallback flow concept that receives any residual (Δ BS − Σ filter matches). Null when no default is declared; behavior on residual then follows ``validation_mode``.
+     * Element id of the default change tag — the fallback flow concept that receives any residual (Δ BS − Σ filter matches). Null when no default is declared; behavior on residual then follows ``validation_mode``.
      */
     default_change_tag_element_id?: string | null;
     /**
      * Default Change Tag Qname
      *
-     * QName of the Tier 1 default change tag (e.g. ``rs-gaap:IncreaseDecreaseInCashAndCashEquivalents``). Round-tripped for caller convenience and operator-readable envelopes; ``default_change_tag_element_id`` is authoritative. Null iff ``default_change_tag_element_id`` is null.
+     * QName of the default change tag (e.g. ``rs-gaap:IncreaseDecreaseInCashAndCashEquivalents``). Round-tripped for caller convenience and operator-readable envelopes; ``default_change_tag_element_id`` is authoritative. Null iff ``default_change_tag_element_id`` is null.
      */
     default_change_tag_qname?: string | null;
     /**
@@ -12231,8 +12230,7 @@ export type TaxonomyBlockEnvelope = {
  *
  * Exactly one of ``rule_pattern`` (arithmetic) or ``rule_check_kind``
  * (model-structure) is non-null per row, enforced by the
- * ``check_rule_pattern_kind_xor`` DB constraint. See
- * information-block.md §5.2.2.
+ * ``check_rule_pattern_kind_xor`` DB constraint.
  */
 export type TaxonomyBlockRule = {
     /**
@@ -12296,8 +12294,7 @@ export type TaxonomyBlockRule = {
  * ``LeafHasClassification``, ``LibraryOriginImmutability``,
  * ``UniqueQNameInTaxonomy``) are system-managed — they're auto-emitted
  * by :func:`emit_auto_rules` at taxonomy-block creation time and
- * populate ``rules.rule_check_kind`` instead of ``rule_pattern``. See
- * information-block.md §5.2.2 for the axis split.
+ * populate ``rules.rule_check_kind`` instead of ``rule_pattern``.
  */
 export type TaxonomyBlockRuleRequest = {
     /**
@@ -13562,8 +13559,8 @@ export type ValidationLite = {
  * Pass/fail/skip counts for one ``rule_category`` within a block's
  * verification results.
  *
- * Drives the per-category accordions in the Verification Results panel
- * (financial-viewer §7.12). ``category`` is the rule's ``rule_category``
+ * Drives the per-category accordions in the Verification Results panel.
+ * ``category`` is the rule's ``rule_category``
  * (one of the cm:VerificationRule subclasses), resolved by joining each
  * result to its Rule.
  */
@@ -13651,7 +13648,7 @@ export type VerificationResultLite = {
  * Server-computed aggregate of a block's ``verification_results``.
  *
  * Overall counts plus a per-``rule_category`` breakdown, so the viewer
- * renders the grouped Verification Results panel (financial-viewer §7.12)
+ * renders the grouped Verification Results panel
  * without a client-side results→rules join. Status closure is
  * ``pass | fail | error | skipped`` (the ``public.verification_results``
  * CHECK); ``total`` is their sum.


### PR DESCRIPTION
## Summary

`npm run generate` was failing at the `generate:graphql` step with `Syntax Error: Unexpected Name "DIRECTIVE_DEFINITION"`. This was a GraphQL version skew: the backend's `graphql-core` (3.2.11) advertises the built-in `@deprecated` directive on the newer-spec `DIRECTIVE_DEFINITION` location, which our `graphql-js` (16.x) parser doesn't recognize. graphql-codegen introspects the live backend, serializes the schema back to SDL (`directive @deprecated(...) on ... | DIRECTIVE_DEFINITION`), and re-parses it — `graphql-js` rejects the unknown location keyword and the build dies.

## Changes

- **`codegen.ts`** (the fix): route schema introspection through a `customFetch` hook that strips any directive location not in `graphql-js`'s known set (`Object.values(DirectiveLocation)`) from the introspection response before codegen builds the schema. Filtering against the full known set — rather than hardcoding `DIRECTIVE_DEFINITION` — keeps the build resilient to future `graphql-core`/spec additions. Emits a warning when it drops a location.
- **`clients/graphql/generated/graphql.ts`**, **`sdk/sdk.gen.ts`**, **`sdk/types.gen.ts`**: regenerated outputs from a clean `npm run generate` run now that the pipeline completes.

## Testing

- `npm run generate` (full pipeline) completes cleanly end-to-end; the graphql step logs `Stripped unknown directive location(s) from @deprecated: DIRECTIVE_DEFINITION` and succeeds.
- Pre-commit hook passed: format check, lint, typecheck, and the full vitest suite (278 tests).

## Notes

- The fix is fully self-contained in the client — no backend change required. `@deprecated` on `DIRECTIVE_DEFINITION` is a built-in directive never written in queries, so stripping it has no effect on generated types.
- Version bump / publish remain owned by the maintainer; this PR does not release.
