### PR TITLE
chore(sdk): drop ignore_errors from materialize

### DIFF
--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -6712,12 +6712,6 @@ export type MaterializeOp = {
      */
     rebuild?: boolean;
     /**
-     * Ignore Errors
-     *
-     * Continue past non-fatal row errors
-     */
-    ignore_errors?: boolean;
-    /**
      * Dry Run
      *
      * Validate tables without writing to the graph


### PR DESCRIPTION
## Summary

Regenerated types — `MaterializeOp` no longer accepts `ignore_errors`. The field was removed server-side because LadybugDB 0.18's `COPY (ignore_errors=true)` silently drops valid rows in proportion to batch size.

## Changes

- `sdk/types.gen.ts`: dropped the optional `ignore_errors` field from the materialize request type (regen from the updated API spec).

## Compatibility

Removing an optional field only. No wrapper referenced it, so no facade changes were needed.

## Testing

- Suite green via pre-commit (**281 passed**).
