### PR TITLE
chore(ci): bump workflow actions to Node 24 majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # GitHub Actions — pinned action versions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    labels:
+      - 'dependencies'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,7 +27,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
           token: ${{ secrets.ACTIONS_TOKEN || github.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Get version from package.json
         id: version
@@ -45,7 +45,7 @@ jobs:
       
       - name: Setup Node.js
         if: steps.check-published.outputs.already_published == 'false'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -33,7 +33,7 @@ jobs:
       release_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.repository }}
           ref: ${{ inputs.branch_ref }}
@@ -246,7 +246,7 @@ jobs:
       - name: Create GitHub Release
         if: steps.check-tag.outputs.tag_exists == 'false'
         id: create-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.get-version.outputs.version }}
           name: Release v${{ steps.get-version.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
       


### PR DESCRIPTION
## Summary

Same Node 24 action-runtime sweep as robosystems-holon-viewer#24 — GitHub has deprecated the Node 20 action runtimes. Bumps all workflows to the current latest majors:

- `actions/checkout` v4 → v7 (all workflows)
- `actions/setup-node` v6 → v7 (test.yml, publish.yml, create-release.yml)
- `softprops/action-gh-release` v1 → v3 (tag-release.yml)

No workflow inputs changed — all actions are used with basic, stable parameters (`node-version`, `tag_name`/`name`/`body`, `token`/`fetch-depth`) that carry across these majors.

Also adds a minimal `.github/dependabot.yml` (github-actions ecosystem, monthly — same pattern as the app repos) so action versions stay current; the drift happened because this repo had no Dependabot coverage.

## Testing

- test.yml exercises checkout + setup-node on this PR's CI run
- tag-release.yml/publish.yml bumps get exercised on the next release
