### PR TITLE
fix(ledger): select the chart view arm in the report-package query

### DIFF
--- a/clients/graphql/generated/graphql.ts
+++ b/clients/graphql/generated/graphql.ts
@@ -3551,6 +3551,7 @@ export type GetLedgerReportPackageQuery = {
               elementName: string
               classification: string | null
               balanceType: string | null
+              itemType: string | null
               values: Array<number | null>
               textValue: string | null
               isSubtotal: boolean
@@ -3563,6 +3564,14 @@ export type GetLedgerReportPackageQuery = {
               failures: Array<string>
               warnings: Array<string>
             } | null
+          } | null
+          chart: {
+            panels: Array<{
+              label: string | null
+              itemType: string | null
+              kind: string
+              series: Array<{ key: string; elementId: string; label: string }>
+            }>
           } | null
         }
       }
@@ -7474,6 +7483,10 @@ export const GetLedgerReportPackageDocument = {
                                               },
                                               {
                                                 kind: 'Field',
+                                                name: { kind: 'Name', value: 'itemType' },
+                                              },
+                                              {
+                                                kind: 'Field',
                                                 name: { kind: 'Name', value: 'values' },
                                               },
                                               {
@@ -7540,6 +7553,57 @@ export const GetLedgerReportPackageDocument = {
                                         {
                                           kind: 'Field',
                                           name: { kind: 'Name', value: 'unmappedCount' },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'chart' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'panels' },
+                                          selectionSet: {
+                                            kind: 'SelectionSet',
+                                            selections: [
+                                              {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'label' },
+                                              },
+                                              {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'itemType' },
+                                              },
+                                              {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'kind' },
+                                              },
+                                              {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'series' },
+                                                selectionSet: {
+                                                  kind: 'SelectionSet',
+                                                  selections: [
+                                                    {
+                                                      kind: 'Field',
+                                                      name: { kind: 'Name', value: 'key' },
+                                                    },
+                                                    {
+                                                      kind: 'Field',
+                                                      name: { kind: 'Name', value: 'elementId' },
+                                                    },
+                                                    {
+                                                      kind: 'Field',
+                                                      name: { kind: 'Name', value: 'label' },
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                            ],
+                                          },
                                         },
                                       ],
                                     },

--- a/clients/graphql/queries/ledger/reportPackage.ts
+++ b/clients/graphql/queries/ledger/reportPackage.ts
@@ -152,6 +152,7 @@ export const GET_REPORT_PACKAGE = gql`
                 elementName
                 classification
                 balanceType
+                itemType
                 values
                 textValue
                 isSubtotal
@@ -169,6 +170,18 @@ export const GET_REPORT_PACKAGE = gql`
                 warnings
               }
               unmappedCount
+            }
+            chart {
+              panels {
+                label
+                itemType
+                kind
+                series {
+                  key
+                  elementId
+                  label
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## What

Fixes an internal inconsistency the chart-arm work (#152) surfaced: the **report-package** query (`reportPackage.ts`) selected `view.rendering` but **not** `view.chart`, while the **single-block** query (`informationBlock.ts`) selects both. That made `getReportPackage().items[].block` and `getInformationBlock()` two differently-shaped `InformationBlock` types from the *same* client — a chart-less one and a chart-ful one — which is why a consumer feeding a report-package block into a chart-aware `BlockView` needs a bridging cast (roboledger-app's filed-report viewer).

Mirrors the #152 edit: adds `view.chart { panels { … } }` + `rendering.rows.itemType` to the report-package query so both block-bearing queries yield the same envelope shape. Regen only; no version bump.

**This is the actual fix** for the roboledger-app filed-report cast — not `@robosystems/core` (which references the client's types live and produces no second copy; there's one deduped client 0.5.5 in the tree). Once this republishes, the cast can be removed.

It's also correct forward-looking: when a report bundles a metric block, the report viewer will render its chart.

## Verification

`npm run typecheck` clean; **284 tests** pass; diff scoped to `reportPackage.ts` + the regenerated `graphql.ts` (report-package block now carries `view.chart` + row `itemType`).