### PR TITLE
feat(blocks): series read option + forecast seam flag; F-2 response regen

### DIFF
--- a/clients/LedgerClient.ts
+++ b/clients/LedgerClient.ts
@@ -1085,16 +1085,26 @@ export class LedgerClient {
    * a forecast block's structure id = that scenario's parallel universe
    * (statement envelopes bind its latest computed month, metric
    * envelopes extend the series with "(forecast)"-labeled columns).
+   *
+   * `options.series` renders a statement block as its whole report-set
+   * time series — one column per period; combined with `scenarioId` the
+   * columns cross the actuals/forecast seam and forecast columns carry
+   * `periods[].forecast === true`. Non-statement block types ignore it
+   * (metric envelopes are always the full series).
    */
   async getInformationBlock(
     graphId: string,
     id: string,
-    options?: { scenarioId?: string }
+    options?: { scenarioId?: string; series?: boolean }
   ): Promise<InformationBlock | null> {
     const block = await this.gqlQuery(
       graphId,
       GetInformationBlockDocument,
-      { id, scenarioId: options?.scenarioId ?? null },
+      {
+        id,
+        scenarioId: options?.scenarioId ?? null,
+        series: options?.series ?? false,
+      },
       'Get information block',
       (data) => data.informationBlock ?? null
     )

--- a/clients/graphql/generated/graphql.ts
+++ b/clients/graphql/generated/graphql.ts
@@ -638,6 +638,8 @@ export type InformationBlockRendering = {
 /** One period column in a rendered statement. */
 export type InformationBlockRenderingPeriod = {
   end: Scalars['Date']['output']
+  /** True when this column comes from a forecast scenario's FactSet — the machine-readable seam marker (labels also carry a '(forecast)' suffix, but consumers should key styling off this flag, not label parsing). None/absent = an actuals column. */
+  forecast: Maybe<Scalars['Boolean']['output']>
   label: Maybe<Scalars['String']['output']>
   start: Scalars['Date']['output']
 }
@@ -1684,6 +1686,7 @@ export type QueryHoldingsArgs = {
 export type QueryInformationBlockArgs = {
   id: Scalars['ID']['input']
   scenarioId?: InputMaybe<Scalars['String']['input']>
+  series?: Scalars['Boolean']['input']
 }
 
 export type QueryInformationBlocksArgs = {
@@ -2899,6 +2902,7 @@ export type GetLedgerFiscalCalendarQuery = {
 export type GetInformationBlockQueryVariables = Exact<{
   id: Scalars['ID']['input']
   scenarioId: InputMaybe<Scalars['String']['input']>
+  series?: Scalars['Boolean']['input']
 }>
 
 export type GetInformationBlockQuery = {
@@ -3015,7 +3019,7 @@ export type GetInformationBlockQuery = {
           isSubtotal: boolean
           depth: number
         }>
-        periods: Array<{ start: any; end: any; label: string | null }>
+        periods: Array<{ start: any; end: any; label: string | null; forecast: boolean | null }>
         validation: {
           passed: boolean
           checks: Array<string>
@@ -3157,7 +3161,7 @@ export type ListInformationBlocksQuery = {
           isSubtotal: boolean
           depth: number
         }>
-        periods: Array<{ start: any; end: any; label: string | null }>
+        periods: Array<{ start: any; end: any; label: string | null; forecast: boolean | null }>
         validation: {
           passed: boolean
           checks: Array<string>
@@ -3566,7 +3570,7 @@ export type GetLedgerReportPackageQuery = {
               isSubtotal: boolean
               depth: number
             }>
-            periods: Array<{ start: any; end: any; label: string | null }>
+            periods: Array<{ start: any; end: any; label: string | null; forecast: boolean | null }>
             validation: {
               passed: boolean
               checks: Array<string>
@@ -5747,6 +5751,15 @@ export const GetInformationBlockDocument = {
           variable: { kind: 'Variable', name: { kind: 'Name', value: 'scenarioId' } },
           type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
         },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'series' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Boolean' } },
+          },
+          defaultValue: { kind: 'BooleanValue', value: false },
+        },
       ],
       selectionSet: {
         kind: 'SelectionSet',
@@ -5764,6 +5777,11 @@ export const GetInformationBlockDocument = {
                 kind: 'Argument',
                 name: { kind: 'Name', value: 'scenarioId' },
                 value: { kind: 'Variable', name: { kind: 'Name', value: 'scenarioId' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'series' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'series' } },
               },
             ],
             selectionSet: {
@@ -6002,6 +6020,7 @@ export const GetInformationBlockDocument = {
                                   { kind: 'Field', name: { kind: 'Name', value: 'start' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'end' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                                  { kind: 'Field', name: { kind: 'Name', value: 'forecast' } },
                                 ],
                               },
                             },
@@ -6372,6 +6391,7 @@ export const ListInformationBlocksDocument = {
                                   { kind: 'Field', name: { kind: 'Name', value: 'start' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'end' } },
                                   { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                                  { kind: 'Field', name: { kind: 'Name', value: 'forecast' } },
                                 ],
                               },
                             },
@@ -7553,6 +7573,10 @@ export const GetLedgerReportPackageDocument = {
                                               {
                                                 kind: 'Field',
                                                 name: { kind: 'Name', value: 'label' },
+                                              },
+                                              {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'forecast' },
                                               },
                                             ],
                                           },

--- a/clients/graphql/queries/ledger/informationBlock.ts
+++ b/clients/graphql/queries/ledger/informationBlock.ts
@@ -8,8 +8,8 @@ import { gql } from 'graphql-request'
  * branch. See `local/docs/specs/information-block.md` §2.
  */
 export const GET_INFORMATION_BLOCK = gql`
-  query GetInformationBlock($id: ID!, $scenarioId: String) {
-    informationBlock(id: $id, scenarioId: $scenarioId) {
+  query GetInformationBlock($id: ID!, $scenarioId: String, $series: Boolean! = false) {
+    informationBlock(id: $id, scenarioId: $scenarioId, series: $series) {
       id
       blockType
       name
@@ -134,6 +134,7 @@ export const GET_INFORMATION_BLOCK = gql`
             start
             end
             label
+            forecast
           }
           validation {
             passed
@@ -305,6 +306,7 @@ export const LIST_INFORMATION_BLOCKS = gql`
             start
             end
             label
+            forecast
           }
           validation {
             passed

--- a/clients/graphql/queries/ledger/reportPackage.ts
+++ b/clients/graphql/queries/ledger/reportPackage.ts
@@ -163,6 +163,7 @@ export const GET_REPORT_PACKAGE = gql`
                 start
                 end
                 label
+                forecast
               }
               validation {
                 passed

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -1307,6 +1307,12 @@ export type ComputeForecastResponse = {
      * Skipped
      */
     skipped?: Array<SkippedForecastLite>;
+    /**
+     * Diagnostics
+     *
+     * Articulation notes — a missing cash/earnings anchor, schedule contributions with no base-set landing spot, an absent cash-flow structure. Informational; the walk still computed.
+     */
+    diagnostics?: Array<string>;
 };
 
 /**
@@ -5161,15 +5167,33 @@ export type ForecastMonthLite = {
     /**
      * Balance Sheet Fact Set Id
      *
-     * Scenario BS FactSet upserted for the month (working-capital instants only in F-1 — the full BS roll is a later phase).
+     * Scenario BS FactSet upserted for the month — the full roll: carry-forward, rule-driven working capital, schedule movements, RE roll, balancing cash (A = L + E by construction).
      */
     balance_sheet_fact_set_id?: string | null;
     /**
+     * Cash Flow Fact Set Id
+     *
+     * Scenario CF FactSet upserted for the month — indirect-method, derived from BS deltas + NI, reconciled to the balancing ΔCash.
+     */
+    cash_flow_fact_set_id?: string | null;
+    /**
      * Computed Count
      *
-     * Number of facts emitted for the month across both sets.
+     * Number of facts emitted for the month across all sets.
      */
     computed_count?: number;
+    /**
+     * Verification Passed
+     *
+     * Whether every rule evaluated against the month's scenario sets passed (None = no rules ran for the month).
+     */
+    verification_passed?: boolean | null;
+    /**
+     * Verification Failures
+     *
+     * Failed/errored rule messages for the month (capped).
+     */
+    verification_failures?: Array<string>;
 };
 
 /**
@@ -11020,6 +11044,12 @@ export type RenderingPeriodLite = {
      * Label
      */
     label?: string | null;
+    /**
+     * Forecast
+     *
+     * True when this column comes from a forecast scenario's FactSet — the machine-readable seam marker (labels also carry a '(forecast)' suffix, but consumers should key styling off this flag, not label parsing). None/absent = an actuals column.
+     */
+    forecast?: boolean | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

SDK surface for robosystems **#920** (F-2 articulation) + **#921** (F-4 statement-series projection). Generated against the combined backend.

- `LedgerClient.getInformationBlock(graphId, id, { scenarioId?, series? })` — `series: true` renders a statement block as its whole report-set time series (one column per period; with `scenarioId` the columns cross the actuals/forecast seam). `$series` threads through `GET_INFORMATION_BLOCK`.
- `rendering.periods[]` gains `forecast` (the machine-readable seam marker) on both information-block queries **and** the report-package query — the #153 shape-parity lesson. The legacy `statement` query keeps its `PeriodSpec` shape (no forecast field on that type).
- OpenAPI regen: `ForecastMonthLite.cash_flow_fact_set_id` / `verification_passed` / `verification_failures`, `ComputeForecastResponse.diagnostics`.

Gate: `npm run test:all` green (284 tests, typecheck, build). Merge after the backend PRs; publish on your cadence — roboledger-app's `/plan` PR consumes the published version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)