### PR TITLE
feat(sdk): regen — close statement-stamp fields + element documentation

### DIFF
--- a/clients/graphql/generated/graphql.ts
+++ b/clients/graphql/generated/graphql.ts
@@ -560,6 +560,8 @@ export type InformationBlockConnection = {
 export type InformationBlockElement = {
   balanceType: Maybe<Scalars['String']['output']>
   code: Maybe<Scalars['String']['output']>
+  /** The element's documentation-role label — the catalog's authoritative value semantics (e.g. whether a percent driver is a growth rate or a rate-on-base fraction). None when the element carries no documentation label. */
+  documentation: Maybe<Scalars['String']['output']>
   /** concept | abstract | axis | member | hypercube */
   elementType: Scalars['String']['output']
   id: Scalars['String']['output']

--- a/sdk/sdk.gen.ts
+++ b/sdk/sdk.gen.ts
@@ -1962,7 +1962,7 @@ export const setCloseTarget = <ThrowOnError extends boolean = false>(options: Op
 /**
  * Close Fiscal Period
  *
- * Lock a single fiscal period. Posts draft entries, runs the balance-sheet equation check, advances `closed_through` by one, and auto-advances `close_target` if this close caught up to it. Period must be exactly `closed_through + 1` — sequence violations return 422 with structured `blockers`. Common blockers: `sync_stale` (override with `allow_stale_sync=true` after manual verification), `period_incomplete` (draft entries unbalanced), `sequence_violation` (out-of-order).
+ * Lock a single fiscal period. Posts draft entries, runs the balance-sheet equation check, advances `closed_through` by one, auto-advances `close_target` if this close caught up to it, and stamps the period's canonical statement FactSets from the posted ledger (`statements_stamped` / `stamped_statement_sets` in the response; soft-skipped with `statement_stamp_note` when reporting isn't set up). Period must be exactly `closed_through + 1` — sequence violations return 422 with structured `blockers`. Common blockers: `sync_stale` (override with `allow_stale_sync=true` after manual verification), `period_incomplete` (draft entries unbalanced), `sequence_violation` (out-of-order).
  *
  * **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
  */
@@ -1979,7 +1979,7 @@ export const closePeriod = <ThrowOnError extends boolean = false>(options: Optio
 /**
  * Reopen Fiscal Period
  *
- * Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-back). The required `reason` is captured in the audit log. Use sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared filings).
+ * Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-back). Retracts the month's canonical statement FactSets (a reopened month is no longer a closed assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared filings).
  *
  * **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
  */

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -1230,6 +1230,34 @@ export type ClosePeriodResponse = {
      * ids of schedule Structures whose rules were evaluated during the close. Pairs with rule_summary.
      */
     evaluated_structure_ids?: Array<string>;
+    /**
+     * Statements Stamped
+     *
+     * Whether the close stamped the period's canonical statement FactSets (the close-time pivot). False when the tenant hasn't set up reporting yet — see statement_stamp_note.
+     */
+    statements_stamped?: boolean;
+    /**
+     * Statement Stamp Note
+     *
+     * Soft-skip reason when statements_stamped is false: no_coa_mapping | no_entity | no_statement_structures | no_taxonomy.
+     */
+    statement_stamp_note?: string | null;
+    /**
+     * Stamped Statement Sets
+     *
+     * structure_id -> fact_set_id for every canonical statement FactSet minted by this close (report_id NULL; replaced on reclose).
+     */
+    stamped_statement_sets?: {
+        [key: string]: string;
+    };
+    /**
+     * Statement Rule Summary
+     *
+     * Aggregated statement-rule verification outcome across the stamped structures — keys: pass/fail/error/skipped. None when no statement rules exist. Distinct from rule_summary (the schedule-rule pass).
+     */
+    statement_rule_summary?: {
+        [key: string]: number;
+    } | null;
 };
 
 /**
@@ -3977,6 +4005,12 @@ export type ElementLite = {
      * Value-domain vocabulary (monetary | ratio | percent | multiple | days | string | …). None means untyped; fall back to is_monetary.
      */
     item_type?: string | null;
+    /**
+     * Documentation
+     *
+     * The element's documentation-role label — the catalog's authoritative value semantics (e.g. whether a percent driver is a growth rate or a rate-on-base fraction). None when the element carries no documentation label.
+     */
+    documentation?: string | null;
 };
 
 /**
@@ -7090,13 +7124,21 @@ export type LeverAssertionLite = {
  * One lever's asserted values for the scenario.
  *
  * ``qname`` must resolve to an ``rs-driver:*`` catalog element (the
- * create handler rejects anything else). Value conventions follow the
- * catalog: percent levers are decimals per month (0.03 = 3%/month),
- * days levers are day counts.
+ * create handler rejects anything else). Each lever's value semantics
+ * are defined by its catalog element's documentation — surfaced as
+ * ``documentation`` on the elements bundled in the forecast block's
+ * envelope (``get-information-block``). Percent levers are decimals but
+ * their *meaning* varies by lever: growth levers are month-over-month
+ * rates (``RevenueGrowthRate`` 0.03 = +3%/month, compounding), while
+ * rate-on-base levers are fractions of the same month's base
+ * (``CostOfRevenueRate`` 0.62 = cost of revenue at 62% of that month's
+ * revenues — not a growth rate). Days levers (``DaysSalesOutstanding``,
+ * ``DaysPayableOutstanding``) are day counts.
  *
  * ``value`` is a uniform fill across the whole horizon;
  * ``values_by_period`` overrides individual months (``"YYYY-MM"``
- * keys). At least one of the two must be provided. Months covered by
+ * keys) — e.g. a margin-compression ramp asserts a different rate each
+ * month. At least one of the two must be provided. Months covered by
  * neither carry no assertion — the lever's rule is inactive for that
  * month and its target falls to the engine's carry-forward default.
  */
@@ -15332,7 +15374,7 @@ export type UpdateForecastArm = {
      */
     block_type: 'forecast';
     /**
-     * Forecast update payload.
+     * Forecast update payload. Updating does NOT recompute — lever, horizon, or base-period changes leave the scenario's computed months stale until the next `compute-forecast` run.
      */
     payload: UpdateForecastRequest;
 };


### PR DESCRIPTION
Regenerated TypeScript client from the current server OpenAPI + GraphQL schema. Picks up already-merged server changes; **all additive, no breaking changes**.

## Changes

**Close-stamps-statements (server #922/#923)** — `sdk/types.gen.ts`, `sdk/sdk.gen.ts`
- close-period response gains `statements_stamped`, `statement_stamp_note`, `stamped_statement_sets`, `statement_rule_summary`
- reopen-period description notes canonical-set retraction on reopen

**Forecast MCP legibility (server #924)** — `sdk/types.gen.ts`, `clients/graphql/generated/graphql.ts`
- REST `ElementLite` and GraphQL element gain `documentation` — the catalog element's authoritative value semantics (growth-rate vs rate-on-base fraction)
- lever-assertion request types clarify growth vs rate-on-base lever meaning

## Verification

- `npm run test:all` green (validate + 284 tests + build)
- Pure regen output — no hand edits
- Version bump / release handled separately by the publish flow