### PR TITLE
SDK regen — graph tier storage limit, reopen-period semantics

### DIFF
--- a/sdk/sdk.gen.ts
+++ b/sdk/sdk.gen.ts
@@ -1979,7 +1979,7 @@ export const closePeriod = <ThrowOnError extends boolean = false>(options: Optio
 /**
  * Reopen Fiscal Period
  *
- * Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-back). Retracts the month's canonical statement FactSets (a reopened month is no longer a closed assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared filings).
+ * Reopen a closed period for adjustment. Reopening the current `closed_through` decrements it by one; reopening an earlier period is a prior-period adjustment and leaves `closed_through` unchanged — re-closing it restores the period without advancing the pointer. Either way the period's entries become writable again. Retracts the month's canonical statement FactSets (a reopened month is no longer a closed assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared filings).
  *
  * **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
  */

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -5968,6 +5968,12 @@ export type GraphSubscriptionTier = {
      * Instance type
      */
     instance_type?: string | null;
+    /**
+     * Instance Storage Limit Gb
+     *
+     * Soft storage cap for the instance in GB
+     */
+    instance_storage_limit_gb?: number;
 };
 
 /**
@@ -11574,7 +11580,7 @@ export type RenderingRowLite = {
 /**
  * ReopenPeriodOperation
  *
- * Reopen the most recently closed fiscal period.
+ * Reopen a closed fiscal period.
  */
 export type ReopenPeriodOperation = {
     /**
@@ -11592,7 +11598,7 @@ export type ReopenPeriodOperation = {
     /**
      * Period
      *
-     * Period to reopen, in YYYY-MM. Must equal current `closed_through` — only the most recent close can be undone.
+     * Period to reopen, in YYYY-MM. Any closed period may be reopened. Reopening the current `closed_through` retreats it by one month; reopening an earlier period leaves `closed_through` where it is (a prior-period adjustment), and its re-close restores the period without moving the pointer.
      */
     period: string;
 };


### PR DESCRIPTION
Regenerated against the live spec now that robosystems **v1.6.14** is deployed. Two backend deltas since the last regen (#159, which covered robosystems#937/#938).

## `GraphSubscriptionTier.instance_storage_limit_gb`

```ts
instance_storage_limit_gb?: number
```

The offerings router had been computing this value since the field was introduced, but it was never declared on the response model — so Pydantic silently dropped it for **every** tier, Standard included. Fixed in robosystems#945; this regen is what makes it reachable from the SDK.

Unblocks two follow-ups that currently carry workarounds:

- `robosystems-core` reads it through a narrow cast (`tier as { instance_storage_limit_gb?: number }`) because the pinned client predates the field
- `robosystems-app` (#227) omits storage from its live price reconciliation for the same reason, falling back to a constant

## `reopen-period`

The description now covers prior-period adjustment: reopening an earlier period leaves `closed_through` unchanged rather than decrementing it, and re-closing restores the period without advancing the pointer.

## Scope

Only `sdk/` is tracked — the root `*.gen.*` files are gitignored and rebuilt by `prepare:publish` at release time, so this diff is the complete change.

## Testing

`npm run test:all` — 284 tests, format, lint, typecheck, build all green.