### PR TITLE
fix(ledger): surface the typed liveFinancialStatement result

### DIFF
--- a/clients/LedgerClient.ts
+++ b/clients/LedgerClient.ts
@@ -106,6 +106,7 @@ import type {
   LedgerAgentResponse,
   LinkEntityTaxonomyRequest,
   LiveFinancialStatementRequest,
+  LiveFinancialStatementResponse,
   OperationEnvelope,
   PreviewEventBlockResponse,
   PublishListMemberResponse,
@@ -1833,12 +1834,12 @@ export class LedgerClient {
   async liveFinancialStatement(
     graphId: string,
     body: LiveFinancialStatementRequest
-  ): Promise<Record<string, unknown>> {
+  ): Promise<LiveFinancialStatementResponse> {
     const envelope = await this.callOperation(
       'Live financial statement',
       liveFinancialStatement({ path: { graph_id: graphId }, body })
     )
-    return (envelope.result ?? {}) as Record<string, unknown>
+    return this.requireResult('Live financial statement', envelope.result)
   }
 
   /**


### PR DESCRIPTION
## Summary

The 0.5.13 regen (#161) typed the *generated* `liveFinancialStatement` call — its envelope `result` is now `LiveFinancialStatementResponse` instead of `any`. But the hand-written facade still declared `Promise<Record<string, unknown>>` and cast the result away, so **no consumer could actually see the new type**. The regen's benefit stopped at the generated layer.

I caught this while adopting 0.5.13 in roboledger: the generated types were correct, but `clients.ledger.liveFinancialStatement()` still returned an untyped record.

## Change

`callOperation<T>` is already generic and preserves `T`, so this is just a matter of not erasing it:

```diff
-  ): Promise<Record<string, unknown>> {
+  ): Promise<LiveFinancialStatementResponse> {
     const envelope = await this.callOperation(...)
-    return (envelope.result ?? {}) as Record<string, unknown>
+    return this.requireResult('Live financial statement', envelope.result)
   }
```

This matches `computeMetrics` and the other typed operation wrappers.

## Behaviour change worth noting

An envelope with **no result** previously resolved to `{}`; it now throws, exactly as `computeMetrics` already does.

For a statement read that's the better failure mode. roboledger's statements page currently does `Array.isArray(result.periods) ? result : null` — so an empty `{}` renders as "no data available", making a broken response indistinguishable from an empty ledger. An exception surfaces it as the error it is, and the page already has a `try/catch` that displays it.

## What it unblocks

roboledger's `ledger/statements/content.tsx` hand-maintains `LiveStatement`, `LiveFactRow` and `LivePeriod` interfaces and casts through `as unknown as LiveStatement` **solely because of this signature**. All of that can be deleted once this ships.

## Testing

`npm run test:all` green — 10 files / 284 tests, plus format check, lint, typecheck and build. Pre-commit hook ran the same suite. Confirmed the emitted declaration now reads:

```ts
liveFinancialStatement(graphId: string, body: LiveFinancialStatementRequest): Promise<LiveFinancialStatementResponse>;
```

## Notes

- `financialStatementAnalysis` and `buildFactGrid` still return `Record<string, unknown>`. That's correct for now — their backend routes aren't parameterised (`OperationEnvelope` without a result type), so there's no type to surface yet. Worth the same treatment if/when those routes are typed backend-side.
- Needs a release to reach roboledger; that's yours to cut.
