### PR TITLE
fix(ledger): correct updateEntity and createSchedule response shapes

### DIFF
--- a/clients/LedgerClient.test.ts
+++ b/clients/LedgerClient.test.ts
@@ -815,13 +815,20 @@ describe('LedgerClient', () => {
 
   describe('createSchedule', () => {
     it('serializes options into snake_case body and converts the result', async () => {
+      // `create-information-block` returns an InformationBlockEnvelope. The
+      // previous mock invented a ScheduleCreatedResponse-shaped body that the
+      // server never sends, which is why the facade reading `structure_id`
+      // looked correct here while returning `structureId: undefined` in
+      // production.
       mockFetch.mockResolvedValueOnce(
         envelopeResponse('create-schedule', {
-          structure_id: 'str_1',
+          id: 'str_1',
+          block_type: 'schedule',
           name: 'Depreciation — Laptops',
+          display_name: 'Depreciation — Laptops',
+          category: 'schedule',
           taxonomy_id: 'tax_depreciation',
-          total_periods: 36,
-          total_facts: 36,
+          facts: new Array(36).fill({ id: 'fact' }),
         })
       )
       const result = await client.createSchedule('graph_1', {
@@ -835,8 +842,11 @@ describe('LedgerClient', () => {
           creditElementId: 'elem_accum_depr',
         },
       })
-      expect(result.totalPeriods).toBe(36)
+      // The block's own id IS the structure id — this is the assertion that
+      // would have caught the bug.
+      expect(result.structureId).toBe('str_1')
       expect(result.taxonomyId).toBe('tax_depreciation')
+      expect(result.totalFacts).toBe(36)
 
       const req = mockFetch.mock.calls[0][0] as Request
       const body = JSON.parse(await req.text())

--- a/clients/LedgerClient.ts
+++ b/clients/LedgerClient.ts
@@ -104,6 +104,7 @@ import type {
   InitializeLedgerRequest,
   JournalEntryResponse,
   LedgerAgentResponse,
+  LedgerEntityResponse,
   LinkEntityTaxonomyRequest,
   LiveFinancialStatementRequest,
   LiveFinancialStatementResponse,
@@ -423,6 +424,26 @@ export interface ClosePeriodResult {
   evaluatedStructureIds: string[]
 }
 
+/**
+ * Result of `createSchedule`.
+ *
+ * Deliberately narrower than {@link ScheduleCreated}: `create-information-block`
+ * returns an InformationBlockEnvelope, which carries no period/rule rollup.
+ * This method previously advertised `totalPeriods` / `ruleSummary` and decoded
+ * a `structure_id` that isn't on the wire, so every one of those fields —
+ * including `structureId` — read `undefined` at runtime. Use
+ * {@link LedgerClient.rebuildSchedule} when you need the rebuild summary.
+ */
+export interface ScheduleBlockCreated {
+  /** The created block's id, which is the structure id. */
+  structureId: string
+  name: string
+  /** Null when the created block carries no taxonomy association. */
+  taxonomyId: string | null
+  /** Fact count on the created block; null when the response omitted facts. */
+  totalFacts: number | null
+}
+
 export interface ScheduleCreated {
   structureId: string
   name: string
@@ -572,7 +593,15 @@ export class LedgerClient {
         body: updates,
       })
     )
-    return envelope.result as unknown as LedgerEntity
+    // The REST envelope carries LedgerEntityResponse (snake_case); LedgerEntity
+    // is the GraphQL camelCase shape that getEntity returns. The old
+    // `as unknown as` cast asserted one was the other, so every multi-word
+    // field — parentEntityId, isParent, legalName, entityType … — read
+    // `undefined` on the object handed back after a save. Map instead, so the
+    // declared return type is true and updateEntity stays interchangeable with
+    // getEntity.
+    const raw = this.requireResult('Update entity', envelope.result)
+    return entityResponseToCamel(raw)
   }
 
   // ── Summary ────────────────────────────────────────────────────────
@@ -1236,7 +1265,10 @@ export class LedgerClient {
     return (envelope.result ?? { deleted: true }) as DeleteInformationBlockResponse
   }
 
-  async createSchedule(graphId: string, options: CreateScheduleOptions): Promise<ScheduleCreated> {
+  async createSchedule(
+    graphId: string,
+    options: CreateScheduleOptions
+  ): Promise<ScheduleBlockCreated> {
     const body: CreateInformationBlockRequest = {
       block_type: 'schedule',
       payload: {
@@ -1267,14 +1299,19 @@ export class LedgerClient {
       'Create schedule',
       createInformationBlock({ path: { graph_id: graphId }, body })
     )
-    const raw = envelope.result as unknown as RawScheduleCreatedResult
+    // `create-information-block` returns an InformationBlockEnvelope, not the
+    // ScheduleCreatedResponse shape this used to decode — there is no
+    // `structure_id` / `total_periods` / `total_facts` / `rule_summary` on the
+    // wire, so all four read `undefined` and callers got
+    // `structureId: undefined`. The block's own `id` is the structure id.
+    // `rebuildSchedule` below is unaffected: that route does return
+    // ScheduleCreatedResponse.
+    const block = this.requireResult('Create schedule', envelope.result)
     return {
-      structureId: raw.structure_id,
-      name: raw.name,
-      taxonomyId: raw.taxonomy_id,
-      totalPeriods: raw.total_periods,
-      totalFacts: raw.total_facts,
-      ruleSummary: raw.rule_summary ?? null,
+      structureId: block.id,
+      name: block.name,
+      taxonomyId: block.taxonomy_id ?? null,
+      totalFacts: block.facts?.length ?? null,
     }
   }
 
@@ -2365,4 +2402,46 @@ function rawFiscalCalendarToCamel(raw: RawFiscalCalendar): LedgerFiscalCalendar 
       closedAt: p.closed_at ?? null,
     })),
   }
+}
+
+/**
+ * Map the REST `LedgerEntityResponse` (snake_case) onto the GraphQL
+ * `LedgerEntity` (camelCase) that `getEntity` returns, so callers can treat the
+ * result of a read and a write interchangeably.
+ */
+function entityResponseToCamel(raw: LedgerEntityResponse): LedgerEntity {
+  return {
+    id: raw.id,
+    name: raw.name,
+    legalName: raw.legal_name ?? null,
+    uri: raw.uri ?? null,
+    cik: raw.cik ?? null,
+    ticker: raw.ticker ?? null,
+    exchange: raw.exchange ?? null,
+    sic: raw.sic ?? null,
+    sicDescription: raw.sic_description ?? null,
+    category: raw.category ?? null,
+    stateOfIncorporation: raw.state_of_incorporation ?? null,
+    fiscalYearEnd: raw.fiscal_year_end ?? null,
+    taxId: raw.tax_id ?? null,
+    lei: raw.lei ?? null,
+    industry: raw.industry ?? null,
+    entityType: raw.entity_type ?? null,
+    phone: raw.phone ?? null,
+    website: raw.website ?? null,
+    status: raw.status ?? null,
+    isParent: raw.is_parent ?? null,
+    parentEntityId: raw.parent_entity_id ?? null,
+    source: raw.source ?? null,
+    sourceId: raw.source_id ?? null,
+    sourceGraphId: raw.source_graph_id ?? null,
+    connectionId: raw.connection_id ?? null,
+    addressLine1: raw.address_line1 ?? null,
+    addressCity: raw.address_city ?? null,
+    addressState: raw.address_state ?? null,
+    addressPostalCode: raw.address_postal_code ?? null,
+    addressCountry: raw.address_country ?? null,
+    createdAt: raw.created_at ?? null,
+    updatedAt: raw.updated_at ?? null,
+  } as LedgerEntity
 }


### PR DESCRIPTION
## Summary

Two facade methods decoded response shapes the server does not send. Both were hidden by `as unknown as` casts, and **both cause live, user-visible breakage in roboledger today**. Found by a pre-release audit of the hand-written client layer; I verified each against `sdk/types.gen.ts` and the backend route registration before changing anything.

## 1. `updateEntity` returned snake_case data typed as camelCase

`UpdateEntityResponses[200]` is `OperationEnvelopeLedgerEntityResponse`, whose `result` is **`LedgerEntityResponse` — snake_case** (`legal_name`, `is_parent`, `parent_entity_id`, `entity_type`, `state_of_incorporation`, …). The method cast that to **`LedgerEntity`**, the GraphQL **camelCase** type `getEntity` returns, and declared it as the return type.

So every multi-word field on the returned object was `undefined`.

**Live consequence:** `roboledger-app/src/app/(app)/entity/content.tsx` does `setEntity(updated)` and immediately reads `updated.parentEntityId` / `updated.isParent`. After a successful save the detail panel blanks out its camelCase-named fields and the entity dropdown loses parent/child state, until the page is reloaded.

Now mapped through `entityResponseToCamel`, so the declared type is true and `updateEntity` stays interchangeable with `getEntity`.

## 2. `createSchedule` read four fields that aren't on the wire

It posts to `create-information-block`, which returns an **`InformationBlockEnvelope`** — `{id, block_type, name, display_name, category, taxonomy_id, information_model, artifact, elements, connections, facts, rules}`. There is **no `structure_id`, `total_periods`, `total_facts` or `rule_summary`**. All four read `undefined`, while being declared non-optional.

**Live consequence:** callers got `structureId: undefined`. roboledger's `NewScheduleModal` passes it to `onCreated?.(created.structureId)`, so the close page cannot select the schedule the user just created.

The block's own `id` **is** the structure id. `createSchedule` now returns the narrower `ScheduleBlockCreated`, reflecting what the response actually contains.

`ScheduleCreated` is **unchanged** and still used by `rebuildSchedule` — that route genuinely does return `ScheduleCreatedResponse`, so it was correct all along. The docstring claiming both return "the same shape" was wrong.

## The test that let this through

`LedgerClient.test.ts` mocked an invented `ScheduleCreatedResponse`-shaped body, so it passed green against a wire shape the server stopped sending. It now mocks a real `InformationBlockEnvelope` and asserts `structureId` — the assertion that would have caught this. Verified it fails against the old implementation before fixing.

## Breaking

Both return types change. Given the current shapes are already wrong **at runtime**, this is worth a **minor bump with a changelog note** rather than a patch: consumers need the compile error to find their call sites. roboledger reads `totalPeriods` nowhere, so its only required change is none — it already just uses `structureId`.

## Testing

`npm run test:all` green — 10 files / 284 tests, format, lint, typecheck, build. Pre-commit hook ran the same suite.

## Still outstanding from the same audit

Not in this PR, ranked: `OperationClient` swallows API errors (`getStatus` returns undefined, `cancelOperation` resolves as success on failure); the `"./agent"` package export points at a file that doesn't exist; four `Raw*` interfaces shadow generated models and three have already drifted; `listPublishLists` discards pagination it explicitly selects; leaked SSE connections in `OperatorClient`/`QueryClient` where `close()` is a no-op; `useStreamingQuery` uses a different token source than every other hook, so streaming queries can go out unauthenticated.

Root cause worth addressing after the release: `tsconfig` has `strictNullChecks: false`, which is why `envelope.result` being `T | null` is invisible and `as unknown as` bypasses type-check silently.
