### PR TITLE
Regenerate SDK: fact period windows + org-member repository subscribe

### DIFF
--- a/sdk/sdk.gen.ts
+++ b/sdk/sdk.gen.ts
@@ -901,7 +901,7 @@ export const changeSubscriptionPlan = <ThrowOnError extends boolean = false>(opt
 /**
  * Create Repository Subscription
  *
- * For shared repositories only (sec, industry, etc.). User graph subscriptions are created automatically during provisioning.
+ * For shared repositories only (sec, industry, etc.). User graph subscriptions are created automatically during provisioning. Subscribes the caller by default; org owners and admins may subscribe another member of their organization by passing `user_id`. Billing is charged to the organization either way — repository access is per-user, so the subscriber determines who receives access.
  */
 export const createRepositorySubscription = <ThrowOnError extends boolean = false>(options: Options<CreateRepositorySubscriptionData, ThrowOnError>) => (options.client ?? client).post<CreateRepositorySubscriptionResponses, CreateRepositorySubscriptionErrors, ThrowOnError>({
     security: [{ name: 'X-API-Key', type: 'apiKey' }, { scheme: 'bearer', type: 'http' }],

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -2851,6 +2851,12 @@ export type CreateRepositorySubscriptionRequest = {
      * Plan name for the repository subscription
      */
     plan_name: string;
+    /**
+     * User Id
+     *
+     * Subscribe this user instead of yourself. Org owners and admins only, and the target must belong to the same organization. Omit to subscribe yourself. Repository access is per-user while billing is org-level, so the subscriber is what determines who gets access.
+     */
+    user_id?: string | null;
 };
 
 /**
@@ -5245,11 +5251,23 @@ export type FactRecord = {
      */
     element_name?: string | null;
     /**
+     * Period Start
+     *
+     * Period start date (YYYY-MM-DD); null for instant facts. A duration fact is identified by (start, end) — two facts for the same element can share an end date and differ only here (e.g. a quarterly and a year-to-date figure from the same 10-Q).
+     */
+    period_start?: string | null;
+    /**
      * Period End
      *
      * Period end date (YYYY-MM-DD)
      */
     period_end?: string | null;
+    /**
+     * Duration Type
+     *
+     * Period duration classification (e.g. 'quarterly', 'nine_months', 'annual'); null for instant facts. Use with period_start to tell overlapping windows apart.
+     */
+    duration_type?: string | null;
     /**
      * Value
      *
@@ -16559,7 +16577,7 @@ export type ViewResponse = {
     /**
      * Summary
      *
-     * Per-element aggregates, only when include_summary=true. Note that `total` sums across every returned period, which is meaningful for duration facts and not for instants.
+     * Per-element aggregates, only when include_summary=true. Note that `total` sums across every returned period, which is meaningful for duration facts and not for instants. Overlapping duration windows sharing a period_end (quarter + year-to-date) contribute only the narrowest window, so a quarter is never double-counted inside its own YTD figure.
      */
     summary?: {
         [key: string]: ElementSummary;


### PR DESCRIPTION
## Summary

Regenerated from the current API spec (robosystems main, post-#1048). Three API changes reach the client:

- **`FactRecord` gains `period_start` and `duration_type`** — a duration fact is identified by (start, end), so two facts for the same element can share an end date (quarterly + year-to-date from the same 10-Q). Callers can now tell overlapping windows apart; previously the disambiguation shipped server-side (#1039) but stopped at the DTO.
- **`CreateRepositorySubscriptionRequest` gains optional `user_id`** — org owners/admins can subscribe another member of the same org to a repository (billing stays org-level, access is per-user).
- **`ViewResponse.summary` docs** now state the narrowest-window aggregation rule (a quarter is never double-counted inside its own YTD figure).

## Testing

`npm run test:all` green — validate (prettier + eslint + tsc) + 284 tests + build.

No version bump — that happens at publish.