### PR TITLE
Align report ops with the synchronous backend contract; harden GraphQL transport

### DIFF
--- a/clients/InvestorClient.ts
+++ b/clients/InvestorClient.ts
@@ -42,7 +42,7 @@ import type {
   UpdateSecurityOperation,
 } from '../sdk/types.gen'
 import type { TokenProvider } from './graphql/client'
-import { GraphQLClientCache } from './graphql/client'
+import { GraphQLClientCache, toGraphQLError } from './graphql/client'
 import {
   GetInvestorHoldingsDocument,
   GetInvestorPortfolioBlockDocument,
@@ -59,6 +59,10 @@ import {
   type ListInvestorPositionsQuery,
   type ListInvestorSecuritiesQuery,
 } from './graphql/generated/graphql'
+
+// Re-export the structured GraphQL error type so consumers importing
+// from the `@robosystems/client/investor` subpath can `instanceof` it.
+export { GraphQLError } from './graphql/client'
 
 // ── Friendly types derived from GraphQL codegen ────────────────────────
 
@@ -95,6 +99,8 @@ interface InvestorClientConfig {
    * request so refreshes flow through automatically.
    */
   tokenProvider?: TokenProvider
+  /** GraphQL request timeout in milliseconds (default 60s). */
+  timeout?: number
 }
 
 export class InvestorClient {
@@ -363,7 +369,7 @@ export class InvestorClient {
       return pick(data)
     } catch (err) {
       if (err instanceof ClientError) {
-        throw new Error(`${label} failed: ${JSON.stringify(err.response.errors ?? err.message)}`)
+        throw toGraphQLError(label, err)
       }
       throw err
     }

--- a/clients/LedgerClient.test.ts
+++ b/clients/LedgerClient.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { LedgerClient } from './LedgerClient'
+import { GraphQLError, LedgerClient } from './LedgerClient'
 
 // ── Mock helpers ──────────────────────────────────────────────────────
 //
@@ -201,10 +201,15 @@ describe('LedgerClient', () => {
       expect(headers.get('Authorization')).toBeNull()
     })
 
-    it('tokenProvider that throws falls through unauthenticated', async () => {
-      // Same rationale as the null-return case — a throwing provider
-      // would otherwise crash the request before it even leaves the
-      // client, which is worse than a 401.
+    it('tokenProvider that throws fails the request fast', async () => {
+      // A throwing provider means the caller *intended* to authenticate
+      // but couldn't produce a credential. Sending the request
+      // unauthenticated would surface as a confusing 401 far from the
+      // real failure — instead the SDK fails fast with an error naming
+      // the tokenProvider and how to fix it (matching the Python
+      // client, which raises when its credential is missing). A
+      // provider that deliberately has no credential returns `null`
+      // (see the null-return test above) and still goes through.
       const brokenClient = new LedgerClient({
         baseUrl: 'http://localhost:8000',
         tokenProvider: () => {
@@ -212,11 +217,11 @@ describe('LedgerClient', () => {
         },
       })
       mockFetch.mockResolvedValueOnce(gqlResponse({ entity: null }))
-      await expect(brokenClient.getEntity('graph_1')).resolves.toBeNull()
-      const init = mockFetch.mock.calls[0][1] as RequestInit
-      const headers = new Headers(init.headers)
-      expect(headers.get('Authorization')).toBeNull()
-      expect(headers.get('X-API-Key')).toBeNull()
+      await expect(brokenClient.getEntity('graph_1')).rejects.toThrow(
+        /tokenProvider threw while resolving the request credential \(storage unavailable\)/
+      )
+      // The request never left the client.
+      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it('awaits an async tokenProvider before injecting the header', async () => {
@@ -903,6 +908,106 @@ describe('LedgerClient', () => {
       const ack = await client.autoMapElements('graph_1', { mapping_id: 'map_1' })
       expect(ack.status).toBe('pending')
       expect(ack.operationId).toMatch(/^op_/)
+    })
+  })
+
+  // ── Report writes (synchronous operations) ──────────────────────────
+  //
+  // The backend materializes reports inline (`execute_operation` runs
+  // the handler synchronously and returns a completed envelope), so
+  // every report write resolves with the bare typed result — there is
+  // no operationId/SSE handshake on this surface.
+
+  describe('createReport', () => {
+    it('returns the published report header from the envelope result', async () => {
+      mockFetch.mockResolvedValueOnce(
+        envelopeResponse('create-report', {
+          id: 'rpt_1',
+          name: 'Q1 Report',
+          filing_status: 'draft',
+        })
+      )
+      const report = await client.createReport('graph_1', {
+        name: 'Q1 Report',
+        mappingId: 'map_1',
+        periodStart: '2026-01-01',
+        periodEnd: '2026-03-31',
+      })
+      expect(report).toMatchObject({ id: 'rpt_1', name: 'Q1 Report' })
+    })
+
+    it('POSTs snake_case body to the create-report operation URL', async () => {
+      mockFetch.mockResolvedValueOnce(envelopeResponse('create-report', { id: 'rpt_1' }))
+      await client.createReport('graph_42', {
+        name: 'FY25',
+        mappingId: 'map_1',
+        periodStart: '2025-01-01',
+        periodEnd: '2025-12-31',
+      })
+      const req = mockFetch.mock.calls[0][0] as Request
+      expect(req.url).toBe(
+        'http://localhost:8000/extensions/roboledger/graph_42/operations/create-report'
+      )
+      const body = JSON.parse(await req.text())
+      expect(body.mapping_id).toBe('map_1')
+      expect(body.period_start).toBe('2025-01-01')
+      expect(body.period_end).toBe('2025-12-31')
+    })
+
+    it('throws when the envelope carries no result', async () => {
+      mockFetch.mockResolvedValueOnce(envelopeResponse('create-report', null))
+      await expect(
+        client.createReport('graph_1', {
+          name: 'Empty',
+          mappingId: 'map_1',
+          periodStart: '2026-01-01',
+          periodEnd: '2026-03-31',
+        })
+      ).rejects.toThrow(/Create report: operation envelope had no result/)
+    })
+  })
+
+  describe('regenerateReport', () => {
+    it('returns the regenerated report header', async () => {
+      mockFetch.mockResolvedValueOnce(
+        envelopeResponse('regenerate-report', { id: 'rpt_1', generation_status: 'completed' })
+      )
+      const report = await client.regenerateReport('graph_1', 'rpt_1')
+      expect(report).toMatchObject({ id: 'rpt_1', generation_status: 'completed' })
+    })
+  })
+
+  describe('shareReport', () => {
+    it('returns the per-recipient share results', async () => {
+      mockFetch.mockResolvedValueOnce(
+        envelopeResponse('share-report', {
+          report_id: 'rpt_1',
+          results: [{ target_graph_id: 'graph_2', status: 'shared' }],
+        })
+      )
+      const result = await client.shareReport('graph_1', 'rpt_1', 'pl_1')
+      expect(result.results).toHaveLength(1)
+      expect(result.results[0]).toMatchObject({ target_graph_id: 'graph_2' })
+    })
+  })
+
+  describe('fileReport', () => {
+    it('returns the filed report header', async () => {
+      mockFetch.mockResolvedValueOnce(
+        envelopeResponse('file-report', { id: 'rpt_1', filing_status: 'filed' })
+      )
+      const report = await client.fileReport('graph_1', 'rpt_1')
+      expect(report).toMatchObject({ id: 'rpt_1', filing_status: 'filed' })
+    })
+  })
+
+  describe('transitionFilingStatus', () => {
+    it('returns the transitioned report header', async () => {
+      mockFetch.mockResolvedValueOnce(
+        envelopeResponse('transition-filing-status', { id: 'rpt_1', filing_status: 'under_review' })
+      )
+      const report = await client.transitionFilingStatus('graph_1', 'rpt_1', 'under_review')
+      expect(report).toMatchObject({ filing_status: 'under_review' })
     })
   })
 
@@ -1690,6 +1795,63 @@ describe('LedgerClient', () => {
         headers: { 'X-Test': 'y' },
       })
       expect(c).toBeInstanceOf(LedgerClient)
+    })
+  })
+
+  // ── Structured GraphQL errors ───────────────────────────────────────
+
+  describe('GraphQLError', () => {
+    it('throws a GraphQLError carrying the raw errors and status code', async () => {
+      mockFetch.mockResolvedValueOnce(gqlErrorResponse('Access denied'))
+      let caught: unknown
+      try {
+        await client.getEntity('graph_1')
+      } catch (err) {
+        caught = err
+      }
+      expect(caught).toBeInstanceOf(GraphQLError)
+      const gqlErr = caught as GraphQLError
+      // Message format is unchanged from the pre-structured era so
+      // string-matching consumers keep working.
+      expect(gqlErr.message).toMatch(/^Get entity failed: /)
+      expect(gqlErr.errors).toHaveLength(1)
+      expect((gqlErr.errors[0] as { message: string }).message).toBe('Access denied')
+      expect(gqlErr.statusCode).toBe(200)
+    })
+
+    it('is still an Error for consumers catching generically', async () => {
+      mockFetch.mockResolvedValueOnce(gqlErrorResponse('Boom'))
+      await expect(client.getEntity('graph_1')).rejects.toBeInstanceOf(Error)
+    })
+  })
+
+  // ── GraphQL request timeout ─────────────────────────────────────────
+
+  describe('GraphQL timeout', () => {
+    it('attaches an AbortSignal to every GraphQL request', async () => {
+      mockFetch.mockResolvedValueOnce(gqlResponse({ entity: null }))
+      await client.getEntity('graph_1')
+      const init = mockFetch.mock.calls[0][1] as RequestInit
+      expect(init.signal).toBeInstanceOf(AbortSignal)
+      expect(init.signal?.aborted).toBe(false)
+    })
+
+    it('honors a configured timeout by aborting the signal after it elapses', async () => {
+      // Real timers: happy-dom's AbortSignal.timeout schedules on the
+      // native clock, which vitest's fake timers don't intercept. A
+      // 5ms timeout keeps the wait negligible.
+      const quickClient = new LedgerClient({
+        baseUrl: 'http://localhost:8000',
+        token: 'rfs_test_api_key',
+        timeout: 5,
+      })
+      mockFetch.mockResolvedValueOnce(gqlResponse({ entity: null }))
+      await quickClient.getEntity('graph_1')
+      const init = mockFetch.mock.calls[0][1] as RequestInit
+      const signal = init.signal as AbortSignal
+      expect(signal.aborted).toBe(false)
+      await new Promise((resolve) => setTimeout(resolve, 25))
+      expect(signal.aborted).toBe(true)
     })
   })
 })

--- a/clients/LedgerClient.ts
+++ b/clients/LedgerClient.ts
@@ -131,7 +131,7 @@ import type {
   ViewResponse,
 } from '../sdk/types.gen'
 import type { TokenProvider } from './graphql/client'
-import { GraphQLClientCache } from './graphql/client'
+import { GraphQLClientCache, toGraphQLError } from './graphql/client'
 import {
   GetInformationBlockDocument,
   GetInformationBlockWindowedDocument,
@@ -207,6 +207,10 @@ import {
   type MappingCandidatesQuery,
   type ReportDownloadFormat,
 } from './graphql/generated/graphql'
+
+// Re-export the structured GraphQL error type so consumers importing
+// from the `@robosystems/client/ledger` subpath can `instanceof` it.
+export { GraphQLError } from './graphql/client'
 
 // ── Friendly types derived from GraphQL codegen ────────────────────────
 //
@@ -332,19 +336,6 @@ export interface CreateReportOptions {
   periodType?: string
   comparative?: boolean
   periods?: PeriodSpecInput[]
-}
-
-/**
- * Wrapper returned by report write methods — pairs the audit-side
- * envelope fields (`operationId`, `status`) with the typed result
- * payload. Generic on ``T`` so each method advertises its specific
- * result type (e.g. ``ReportResponse`` for creates, ``DeleteResult``
- * for deletes).
- */
-export interface ReportOperationAck<T = unknown> {
-  operationId: string
-  status: OperationEnvelope['status']
-  result: T | null
 }
 
 // ── Write result shapes (envelope.result payloads) ─────────────────────
@@ -536,6 +527,8 @@ interface LedgerClientConfig {
    * request so refreshes flow through automatically.
    */
   tokenProvider?: TokenProvider
+  /** GraphQL request timeout in milliseconds (default 60s). */
+  timeout?: number
 }
 
 export class LedgerClient {
@@ -1941,7 +1934,7 @@ export class LedgerClient {
       return pick(data)
     } catch (err) {
       if (err instanceof ClientError) {
-        throw new Error(`${label} failed: ${JSON.stringify(err.response.errors ?? err.message)}`)
+        throw toGraphQLError(label, err)
       }
       throw err
     }
@@ -1950,13 +1943,11 @@ export class LedgerClient {
   // ── Reports ─────────────────────────────────────────────────────────
 
   /**
-   * Kick off report creation (async). Use the returned `operationId` to
-   * subscribe to progress via SSE, then call `getReport()` once finished.
+   * Generate report facts from the ledger and publish a Report
+   * definition. Synchronous — the backend materializes the report
+   * inline and this resolves with the published report header.
    */
-  async createReport(
-    graphId: string,
-    options: CreateReportOptions
-  ): Promise<ReportOperationAck<ReportResponse>> {
+  async createReport(graphId: string, options: CreateReportOptions): Promise<ReportResponse> {
     const body: CreateReportRequest = {
       name: options.name,
       mapping_id: options.mappingId,
@@ -1973,11 +1964,7 @@ export class LedgerClient {
       'Create report',
       createReport({ path: { graph_id: graphId }, body })
     )
-    return {
-      operationId: envelope.operationId,
-      status: envelope.status,
-      result: envelope.result ?? null,
-    }
+    return this.requireResult('Create report', envelope.result)
   }
 
   /** List all reports for a graph (includes received shared reports). */
@@ -2039,15 +2026,16 @@ export class LedgerClient {
   }
 
   /**
-   * Regenerate an existing report (async). Returns an operation id;
-   * subscribe via SSE for progress.
+   * Re-run fact generation for an existing Report against the latest
+   * ledger state. Synchronous — resolves with the regenerated report
+   * header.
    */
   async regenerateReport(
     graphId: string,
     reportId: string,
     periodStart?: string,
     periodEnd?: string
-  ): Promise<ReportOperationAck<ReportResponse>> {
+  ): Promise<ReportResponse> {
     const envelope = await this.callOperation(
       'Regenerate report',
       regenerateReport({
@@ -2059,11 +2047,7 @@ export class LedgerClient {
         } as Parameters<typeof regenerateReport>[0]['body'],
       })
     )
-    return {
-      operationId: envelope.operationId,
-      status: envelope.status,
-      result: envelope.result ?? null,
-    }
+    return this.requireResult('Regenerate report', envelope.result)
   }
 
   /** Delete a report and its generated facts. */
@@ -2132,12 +2116,14 @@ export class LedgerClient {
   /**
    * Share a published report to every member of a publish list. Each
    * target graph receives a snapshot copy of the report's facts.
+   * Synchronous — per-recipient outcomes appear in the response's
+   * `results` list.
    */
   async shareReport(
     graphId: string,
     reportId: string,
     publishListId: string
-  ): Promise<ReportOperationAck<ShareReportResponse>> {
+  ): Promise<ShareReportResponse> {
     const envelope = await this.callOperation(
       'Share report',
       shareReport({
@@ -2148,41 +2134,35 @@ export class LedgerClient {
         } as Parameters<typeof shareReport>[0]['body'],
       })
     )
-    return {
-      operationId: envelope.operationId,
-      status: envelope.status,
-      result: envelope.result ?? null,
-    }
+    return this.requireResult('Share report', envelope.result)
   }
 
   /**
    * Transition a Report's filing_status to 'filed' — locks the package.
    * Allowed from 'draft' or 'under_review'. Stamps filed_at + filed_by
-   * from the auth context + server clock.
+   * from the auth context + server clock. Synchronous — resolves with
+   * the updated report header.
    */
-  async fileReport(graphId: string, reportId: string): Promise<ReportOperationAck<ReportResponse>> {
+  async fileReport(graphId: string, reportId: string): Promise<ReportResponse> {
     const body: FileReportRequest = { report_id: reportId }
     const envelope = await this.callOperation(
       'File report',
       fileReport({ path: { graph_id: graphId }, body })
     )
-    return {
-      operationId: envelope.operationId,
-      status: envelope.status,
-      result: envelope.result ?? null,
-    }
+    return this.requireResult('File report', envelope.result)
   }
 
   /**
    * Move a Report along the non-file legs of the filing lifecycle
    * (draft ↔ under_review, filed → archived). Use ``fileReport`` to
-   * reach 'filed' so the audit fields land cleanly.
+   * reach 'filed' so the audit fields land cleanly. Synchronous —
+   * resolves with the updated report header.
    */
   async transitionFilingStatus(
     graphId: string,
     reportId: string,
     targetStatus: string
-  ): Promise<ReportOperationAck<ReportResponse>> {
+  ): Promise<ReportResponse> {
     const body: TransitionFilingStatusRequest = {
       report_id: reportId,
       target_status: targetStatus,
@@ -2191,11 +2171,7 @@ export class LedgerClient {
       'Transition filing status',
       transitionFilingStatus({ path: { graph_id: graphId }, body })
     )
-    return {
-      operationId: envelope.operationId,
-      status: envelope.status,
-      result: envelope.result ?? null,
-    }
+    return this.requireResult('Transition filing status', envelope.result)
   }
 
   /** Check if a report was received via sharing (vs locally created). */
@@ -2361,21 +2337,25 @@ export class LedgerClient {
    * calls. Mirrors the GraphQL client's behaviour — dynamic
    * ``tokenProvider`` is consulted first (so JWT rotation flows
    * naturally), then the static ``token`` config. Returns ``null``
-   * when no credential is configured; the caller decides whether to
-   * proceed anonymously or short-circuit with an error.
+   * when no credential is configured (cookie-based / anonymous flows).
+   * A ``tokenProvider`` that **throws** fails the call fast instead of
+   * silently proceeding unauthenticated — matching the Python client,
+   * which raises when its configured credential cannot be resolved.
    */
   private async resolveToken(): Promise<string | null> {
     if (this.config.tokenProvider) {
+      let token: string | null | undefined
       try {
-        const token = await this.config.tokenProvider()
-        return token ?? null
+        token = await this.config.tokenProvider()
       } catch (err) {
-        console.warn(
-          '[RoboSystems SDK] tokenProvider threw — sending unauthenticated request:',
-          err
+        const detail = err instanceof Error ? err.message : String(err)
+        throw new Error(
+          `RoboSystems SDK: tokenProvider threw while resolving the request credential (${detail}). ` +
+            'Fix the tokenProvider passed in the client config (or via setSDKClientConfig) so it ' +
+            'returns the current token, or null to send an unauthenticated (cookie-based) request.'
         )
-        return null
       }
+      return token ?? null
     }
     return this.config.token ?? null
   }

--- a/clients/LibraryClient.ts
+++ b/clients/LibraryClient.ts
@@ -29,7 +29,7 @@
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
 import { ClientError } from 'graphql-request'
 import type { TokenProvider } from './graphql/client'
-import { GraphQLClientCache } from './graphql/client'
+import { GraphQLClientCache, toGraphQLError } from './graphql/client'
 import {
   GetLibraryElementArcsDocument,
   GetLibraryElementClassificationsDocument,
@@ -52,6 +52,10 @@ import {
   type ListLibraryTaxonomyArcsQuery,
   type SearchLibraryElementsQuery,
 } from './graphql/generated/graphql'
+
+// Re-export the structured GraphQL error type so consumers importing
+// from the `@robosystems/client/library` subpath can `instanceof` it.
+export { GraphQLError } from './graphql/client'
 
 // ── Friendly types derived from GraphQL codegen ────────────────────────
 //
@@ -144,6 +148,8 @@ interface LibraryClientConfig {
    * request so refreshes flow through automatically.
    */
   tokenProvider?: TokenProvider
+  /** GraphQL request timeout in milliseconds (default 60s). */
+  timeout?: number
 }
 
 export class LibraryClient {
@@ -388,7 +394,7 @@ export class LibraryClient {
       return pick(data)
     } catch (err) {
       if (err instanceof ClientError) {
-        throw new Error(`${label} failed: ${JSON.stringify(err.response.errors ?? err.message)}`)
+        throw toGraphQLError(label, err)
       }
       throw err
     }

--- a/clients/graphql/client.ts
+++ b/clients/graphql/client.ts
@@ -21,7 +21,58 @@
  * from the query files in clients/graphql/queries/.
  */
 
-import { GraphQLClient } from 'graphql-request'
+import { ClientError, GraphQLClient } from 'graphql-request'
+
+/**
+ * Default request timeout for GraphQL calls, in milliseconds.
+ *
+ * Matches the Python client's httpx default (60 seconds). Without a
+ * timeout a hung backend hangs callers forever — every GraphQL request
+ * carries an `AbortSignal.timeout(...)` so transport stalls surface as
+ * an abort error instead of an eternal pending promise. Override
+ * per-client via `GraphQLClientConfig.timeout`.
+ */
+export const DEFAULT_GRAPHQL_TIMEOUT_MS = 60_000
+
+/**
+ * Structured error thrown by facade GraphQL reads.
+ *
+ * Mirrors the Python client's `GraphQLError` (message, `errors`,
+ * `status_code`): the message keeps the legacy
+ * `"<label> failed: <json>"` format so string-matching consumers keep
+ * working, while the raw GraphQL error objects and HTTP status are
+ * available as structured fields for programmatic handling.
+ */
+export class GraphQLError extends Error {
+  /** Raw GraphQL error objects from the response body (empty for HTTP-level failures). */
+  readonly errors: unknown[]
+  /** HTTP status code, when known. */
+  readonly statusCode?: number
+
+  constructor(message: string, options?: { errors?: unknown[]; statusCode?: number }) {
+    super(message)
+    this.name = 'GraphQLError'
+    this.errors = options?.errors ?? []
+    this.statusCode = options?.statusCode
+  }
+}
+
+/**
+ * Convert a graphql-request `ClientError` into the facade's structured
+ * {@link GraphQLError}, preserving the legacy message format
+ * (`"<label> failed: <json>"`). Shared by the LedgerClient /
+ * InvestorClient / LibraryClient `gqlQuery` catch paths.
+ */
+export function toGraphQLError(label: string, err: ClientError): GraphQLError {
+  const errors = err.response.errors ?? []
+  return new GraphQLError(
+    `${label} failed: ${JSON.stringify(err.response.errors ?? err.message)}`,
+    {
+      errors,
+      statusCode: err.response.status,
+    }
+  )
+}
 
 /**
  * Callback that returns the current auth credential on demand.
@@ -56,6 +107,39 @@ export interface GraphQLClientConfig {
   tokenProvider?: TokenProvider
   headers?: Record<string, string>
   credentials?: 'include' | 'same-origin' | 'omit'
+  /**
+   * Request timeout in milliseconds. Defaults to
+   * {@link DEFAULT_GRAPHQL_TIMEOUT_MS} (60s, matching the Python
+   * client). Applied per request via `AbortSignal.timeout(...)`.
+   */
+  timeout?: number
+}
+
+/**
+ * Wrap the global `fetch` so every request carries a timeout
+ * `AbortSignal`. If a signal is already present on the request we
+ * combine the two via `AbortSignal.any` (whichever aborts first wins);
+ * in environments without `AbortSignal.timeout` support the wrapper
+ * degrades to plain `fetch`.
+ *
+ * `fetch` is resolved from the global scope at call time (not
+ * captured at construction) so test harnesses that swap
+ * `globalThis.fetch` keep working.
+ */
+function createTimeoutFetch(timeoutMs: number): typeof fetch {
+  return (input, init) => {
+    if (typeof AbortSignal.timeout !== 'function') {
+      return fetch(input, init)
+    }
+    const timeoutSignal = AbortSignal.timeout(timeoutMs)
+    const signal =
+      init?.signal != null
+        ? typeof AbortSignal.any === 'function'
+          ? AbortSignal.any([init.signal, timeoutSignal])
+          : init.signal
+        : timeoutSignal
+    return fetch(input, { ...init, signal })
+  }
 }
 
 /**
@@ -91,6 +175,7 @@ export function createGraphQLClient(config: GraphQLClientConfig, graphId: string
   const staticHeaders: Record<string, string> = {
     ...(config.headers ?? {}),
   }
+  const timeoutFetch = createTimeoutFetch(config.timeout ?? DEFAULT_GRAPHQL_TIMEOUT_MS)
 
   // Dynamic-token path: defer credential injection to a per-request
   // middleware so JWT refreshes are picked up without rebuilding or
@@ -101,24 +186,25 @@ export function createGraphQLClient(config: GraphQLClientConfig, graphId: string
     return new GraphQLClient(url, {
       headers: staticHeaders,
       credentials: config.credentials,
+      fetch: timeoutFetch,
       requestMiddleware: async (request) => {
         let token: string | null | undefined
         try {
           token = await providerFn()
         } catch (err) {
-          // A provider failure shouldn't crash the request — fall
-          // through unauthenticated so the backend returns a clean
-          // 401, which is easier to diagnose than a thrown middleware.
-          // We still log a breadcrumb so the failure is visible in
-          // devtools/log aggregators instead of silently disappearing;
-          // silently swallowing provider bugs in production is worse
-          // than the noise.
-
-          console.warn(
-            '[RoboSystems SDK] tokenProvider threw — sending unauthenticated request:',
-            err
+          // Fail fast — a throwing provider means the caller *intended*
+          // to authenticate but couldn't produce a credential. Sending
+          // the request unauthenticated would surface as a confusing
+          // 401 far from the real failure. (Matches the Python client,
+          // which raises when its credential is missing.) A provider
+          // that deliberately has no credential should return `null`
+          // instead — that still sends an unauthenticated request.
+          const detail = err instanceof Error ? err.message : String(err)
+          throw new Error(
+            `RoboSystems SDK: tokenProvider threw while resolving the request credential (${detail}). ` +
+              'Fix the tokenProvider passed in the client config (or via setSDKClientConfig) so it ' +
+              'returns the current token, or null to send an unauthenticated (cookie-based) request.'
           )
-          token = undefined
         }
         if (!token) {
           return request
@@ -142,6 +228,7 @@ export function createGraphQLClient(config: GraphQLClientConfig, graphId: string
     return new GraphQLClient(url, {
       headers,
       credentials: config.credentials,
+      fetch: timeoutFetch,
     })
   }
 
@@ -150,6 +237,7 @@ export function createGraphQLClient(config: GraphQLClientConfig, graphId: string
   return new GraphQLClient(url, {
     headers: staticHeaders,
     credentials: config.credentials,
+    fetch: timeoutFetch,
   })
 }
 

--- a/clients/index.ts
+++ b/clients/index.ts
@@ -20,6 +20,10 @@ import { SSEClient } from './SSEClient'
 // internal `./graphql/client` module path.
 export type { TokenProvider } from './graphql/client'
 
+// Structured GraphQL error thrown by facade reads (LedgerClient /
+// InvestorClient / LibraryClient), plus the default request timeout.
+export { DEFAULT_GRAPHQL_TIMEOUT_MS, GraphQLError } from './graphql/client'
+
 export interface RoboSystemsClientConfig {
   baseUrl?: string
   credentials?: 'include' | 'same-origin' | 'omit'
@@ -38,6 +42,11 @@ export interface RoboSystemsClientConfig {
   headers?: Record<string, string>
   maxRetries?: number
   retryDelay?: number
+  /**
+   * GraphQL request timeout in milliseconds. Defaults to 60s
+   * (matching the Python client's httpx default) when omitted.
+   */
+  timeout?: number
 }
 
 // Properly typed configuration interface
@@ -49,6 +58,7 @@ interface ResolvedConfig {
   headers?: Record<string, string>
   maxRetries: number
   retryDelay: number
+  timeout?: number
 }
 
 export class RoboSystemsClients {
@@ -85,6 +95,7 @@ export class RoboSystemsClients {
       headers: config.headers,
       maxRetries: config.maxRetries || 5,
       retryDelay: config.retryDelay || 1000,
+      timeout: config.timeout,
     }
 
     this.query = new QueryClient({
@@ -117,6 +128,7 @@ export class RoboSystemsClients {
       token: this.config.token,
       tokenProvider: this.config.tokenProvider,
       headers: this.config.headers,
+      timeout: this.config.timeout,
     })
 
     this.investor = new InvestorClient({
@@ -125,6 +137,7 @@ export class RoboSystemsClients {
       token: this.config.token,
       tokenProvider: this.config.tokenProvider,
       headers: this.config.headers,
+      timeout: this.config.timeout,
     })
 
     // Library uses GraphQL and accepts graphId per-call — pass either
@@ -136,6 +149,7 @@ export class RoboSystemsClients {
       token: this.config.token,
       tokenProvider: this.config.tokenProvider,
       headers: this.config.headers,
+      timeout: this.config.timeout,
     })
 
     // Reports consolidated into LedgerClient — alias for backward compat


### PR DESCRIPTION
## Summary

The backend's report operations are synchronous — `execute_operation` runs the handler inline and returns a completed `OperationEnvelope` (`CreateReportRequest`'s own docstring says "materialized synchronously"). This client's async framing around those operations was wrong, and the Python client already exposes the correct contract. This PR converges the TypeScript client on it and closes three adjacent transport gaps. Deliberate breaking change ahead of 1.0.

### 1. Report operations return the bare typed result

`createReport`, `regenerateReport`, `shareReport`, `fileReport`, and `transitionFilingStatus` returned `ReportOperationAck<T>` (`{operationId, status, result}`) with docstrings telling callers to subscribe to progress via SSE — progress that never streams, because the operation has already completed by the time the response arrives. Each method now returns its typed result directly (`ReportResponse`, `ShareReportResponse`), mirroring the Python client's `create_report` → `ReportResponse` contract. An envelope arriving without a result throws (`"<label>: operation envelope had no result"` via the existing `requireResult` path). `ReportOperationAck` is removed from the public surface; docstrings now say the operations are synchronous.

`autoMapElements` (genuinely async, documented ack shape) and `OperationClient` are untouched.

### 2. GraphQL request timeout

`createGraphQLClient` passed no timeout, so a hung backend hung callers forever. Every GraphQL request now carries `AbortSignal.timeout(...)` with a 60s default (`DEFAULT_GRAPHQL_TIMEOUT_MS`, matching the Python client's httpx default), wired through a fetch wrapper handed to `graphql-request`. Configurable via a new optional `timeout` field on `RoboSystemsClientConfig` and the Ledger/Investor/Library client configs. A caller-supplied signal is combined with the timeout via `AbortSignal.any`; environments without `AbortSignal.timeout` degrade to plain fetch.

### 3. Structured GraphQL errors

The three facade `gqlQuery` catch blocks flattened GraphQL errors into `new Error(label + JSON.stringify(errors))`. They now throw a `GraphQLError` (extends `Error`) carrying `errors: unknown[]` and `statusCode?: number`, mirroring the Python client's `GraphQLError`. The message format is byte-for-byte unchanged (`"<label> failed: <json>"`), so consumers string-matching on messages keep working. Exported from `@robosystems/client/clients` and re-exported from the `ledger` / `investor` / `library` subpath modules.

### 4. Missing-credential fail-fast

A `tokenProvider` that threw was caught, logged with `console.warn`, and the request went out unauthenticated — surfacing as a confusing 401 far from the real failure. Both the shared GraphQL request middleware and `LedgerClient.resolveToken` now fail fast with an error naming the tokenProvider and how to fix it, matching the Python client's raise-on-missing-credential behavior. Providers that deliberately return `null` still send unauthenticated (cookie-based) requests — that documented contract is unchanged.

## Breaking changes and frontend call-site impact

Consumers of the five report methods must drop the ack unwrapping. Concretely, in roboledger-app (the only frontend using these methods today):

- `src/app/(app)/reports/new/content.tsx` (~line 241): `const ack = await clients.reports.createReport(...)` then `ack.result?.id` → the method now resolves with the `ReportResponse` itself, so this becomes `const report = await clients.reports.createReport(...)` and `report.id`. The `if (!newReportId)` guard can go — a missing result now rejects inside the SDK.
- `src/app/(app)/reports/[id]/content.tsx` (~line 222): `const ack = await clients.reports.shareReport(...)` then `ack.result?.results ?? []` → `const res = await clients.reports.shareReport(...)` and `res.results` (non-optional on `ShareReportResponse`).
- `src/app/(app)/ledger/close/components/StatementPanel.tsx` (~line 219): calls `createReport` and ignores the return value — no change needed.

Also breaking: any import of the `ReportOperationAck` type fails to compile (none found in the four apps), and a throwing `tokenProvider` now rejects the request instead of sending it unauthenticated — apps whose provider can throw during token refresh should catch inside the provider and return `null` if they want the old proceed-anonymously behavior.

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 295 passed (10 files); 15 tests added/updated: five report-method suites asserting the unwrapped results and the no-result throw, structured `GraphQLError` fields with the legacy message format, timeout signal attachment and expiry, and the tokenProvider fail-fast rejection