### PR TITLE
Seed v1.0.0 curated release notes

### DIFF
--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -1,0 +1,29 @@
+# Curated release notes
+
+`tag-release.yml` generates the GitHub release body from a Claude-written
+changelog of the changes since the last tag. That framing suits routine
+releases but reads poorly for a milestone, where the story is what the version
+_is_ rather than what changed since last Tuesday.
+
+To override it, commit the notes here as `v<version>.md` **before** dispatching
+`create-release.yml`. The file has to exist at the tagged ref, so it belongs in
+release prep alongside the version bump — not added afterwards. When the file is
+present the workflow uses it verbatim and skips the generated changelog, the
+release-statistics section, and the generated-with footer.
+
+No file, no change: the release falls back to the generated changelog. Skipping
+a release is a normal outcome, not a failure.
+
+## Writing a new one
+
+Write the body only. The workflow supplies the `# RoboSystems TypeScript SDK
+v<version>` heading and the links section, so don't repeat them here — start at
+the first line of prose.
+
+The filename is version-specific on purpose: a leftover file can never be picked
+up by a later release.
+
+For this SDK, curated notes are **mandatory for majors and for any minor that
+deprecates surface** — post-1.0, those notes are the compatibility contract:
+they list what changed in the public surface, what is deprecated (and its
+earliest removal major), and what was removed.

--- a/.github/release-notes/v1.0.0.md
+++ b/.github/release-notes/v1.0.0.md
@@ -1,0 +1,59 @@
+The RoboSystems TypeScript SDK is stable.
+
+1.0.0 is a compatibility promise, not a feature release. From this version
+forward: patches are fixes, minors are strictly additive, and anything that
+would break your code — a removed method, a changed return shape, a renamed
+parameter — costs a major and arrives only after a deprecation cycle
+(deprecated surface warns for at least one further minor and 90 days before
+removal).
+
+**The headline guarantee: typed end to end, in the types you already use.**
+Every facade method is typed — GraphQL reads from schema-generated types, REST
+writes from the OpenAPI spec. No `any` in the public surface, and no
+untyped escape hatches to fall through.
+
+## The stable surface
+
+Covered by the promise:
+
+- **`LedgerClient`** — the event-driven ledger: entities, accounts,
+  transactions, journal entries, event blocks and agents, trial balances,
+  mappings and mapping candidates, information blocks (including forecast
+  scenarios and windowed series), fiscal close, live statements, metrics,
+  reports and publish lists
+- **`InvestorClient`** — portfolios, securities, positions, holdings
+- **`LibraryClient`** — taxonomy browsing, structures, element search,
+  classifications, arcs and equivalents
+- **`QueryClient` / `OperationClient` / `SSEClient` / `OperatorClient`** —
+  queries (including streaming and queued), operation monitoring, the AI
+  operator
+- **React hooks** — `useQuery`, `useStreamingQuery`, `useOperation`,
+  `useMultipleOperations`, `useSDKClients`
+- **Auth** — API keys and JWTs with automatic header routing, per-request
+  `tokenProvider` for rotating credentials; structured `GraphQLError` and the
+  queued-work error classes
+- The subpath exports: `/clients`, `/ledger`, `/investor`, `/library`,
+  `/query`, `/operations`, `/sdk`, `/types`, `/client`
+
+Generated internals (`sdk/*.gen.ts`) are implementation detail — import from
+the facade subpaths.
+
+## Breaking changes since 0.6
+
+- Report operations (`createReport`, `regenerateReport`, `shareReport`,
+  `fileReport`, `transitionFilingStatus`) return their typed result directly —
+  the operation-ack wrapper is gone, and the docs now say what the backend
+  does: these operations are synchronous
+- A throwing `tokenProvider` fails the request instead of proceeding
+  unauthenticated with a console warning (a provider returning `null` still
+  sends unauthenticated, preserving cookie-session flows)
+- GraphQL requests carry a configurable 60s timeout; GraphQL failures surface
+  as structured `GraphQLError` (message, `errors[]`, `statusCode`) with the
+  legacy message format preserved
+- The broken `./agent` subpath export is removed; Node 22+ required
+
+## Build on it
+
+Start an integration from the template:
+https://github.com/RoboFinSystems/robosystems-integration-template — or in the
+browser, pair with `@robosystems/core` the way the RoboSystems apps do.


### PR DESCRIPTION
Seeds `.github/release-notes/` ahead of the 1.0.0 dispatch, mirroring the Python client's PR #167: the convention README (curated notes are mandatory for majors and deprecating minors post-1.0 — they are the compatibility contract) and the `v1.0.0.md` body: the stability promise, the typed-end-to-end guarantee, the covered surface including the subpath exports, and the breaking changes since 0.6 (report contract, fail-fast tokenProvider, GraphQL timeout + structured errors, removed ./agent export, Node 22+).

The workflow only reads this file at tag time, so merging now is inert until the dispatch.

## Test plan

Docs-only. Heading omitted per the convention (the workflow supplies `# RoboSystems TypeScript SDK v<version>`); version-specific filename can only affect the 1.0.0 tag.