### PR TITLE
feat(sdk): regenerate for graph-scoped API keys

### DIFF
--- a/sdk/sdk.gen.ts
+++ b/sdk/sdk.gen.ts
@@ -653,7 +653,7 @@ export const listBackups = <ThrowOnError extends boolean = false>(options: Optio
 /**
  * Get temporary download URL for backup
  *
- * Generate a temporary download URL for a backup (unencrypted, compressed .lbug files only)
+ * Generate a temporary download URL for a backup (unencrypted backups only). The filename carries the extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first: `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
  */
 export const getBackupDownloadUrl = <ThrowOnError extends boolean = false>(options: Options<GetBackupDownloadUrlData, ThrowOnError>) => (options.client ?? client).get<GetBackupDownloadUrlResponses, GetBackupDownloadUrlErrors, ThrowOnError>({
     security: [{ name: 'X-API-Key', type: 'apiKey' }, { scheme: 'bearer', type: 'http' }],

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -58,6 +58,12 @@ export type ApiKeyInfo = {
      * Creation timestamp
      */
     created_at: string;
+    /**
+     * Graph Id
+     *
+     * Graph scope; null means account-wide
+     */
+    graph_id?: string | null;
 };
 
 /**
@@ -910,6 +916,12 @@ export type BackupResponse = {
      * Allow Export
      */
     allow_export: boolean;
+    /**
+     * Download Extension
+     *
+     * Extension the download will carry, and therefore how to unpack it: '.lbug.zip' is a ZIP holding the LadybugDB database file, '.lbug.zst' is zstd-compressed (`zstd -d`). Null when the backup is encrypted and so cannot be downloaded.
+     */
+    download_extension?: string | null;
     /**
      * Created At
      */
@@ -2126,6 +2138,12 @@ export type CreateApiKeyRequest = {
      * Optional expiration date in ISO format (e.g. 2024-12-31T23:59:59Z)
      */
     expires_at?: string | null;
+    /**
+     * Graph Id
+     *
+     * Optional graph scope. A scoped key works only for this graph (and its subgraphs) and is the only kind of key accepted in an MCP connector URL. Omit for an account-wide key.
+     */
+    graph_id?: string | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

SDK regeneration against the updated OpenAPI spec. Additive only — rides a minor under the 1.x contract:

- `ApiKeyInfo.graph_id` and `CreateApiKeyRequest.graph_id` — optional graph scope for API keys (pairs with [robosystems#1064](https://github.com/RoboFinSystems/robosystems/pull/1064); merge that first)
- `BackupResponse.download_extension` + updated backup-download docstring — catching up with the self-describing backup format already on main

## Testing

- `npm run test:all` green: 295 tests, lint, format, typecheck, build