### PR TITLE
Fix the missed reconciling-item rename; obligation detail + close receipt split

### DIFF
--- a/clients/LedgerClient.ts
+++ b/clients/LedgerClient.ts
@@ -345,6 +345,13 @@ export interface CreateReportOptions {
 // consumers; for simple ack/ack-with-id payloads we keep the raw shape.
 
 /** Snake-case shape returned in envelope.result for fiscal calendar writes. */
+interface RawObligationDetail {
+  event_id: string
+  schedule_id?: string | null
+  schedule_name?: string | null
+  period: string
+}
+
 interface RawFiscalCalendar {
   graph_id: string
   fiscal_year_start_month: number
@@ -354,6 +361,15 @@ interface RawFiscalCalendar {
   catch_up_sequence: string[]
   closeable_now: boolean
   blockers: string[]
+  // Detail for actionable blockers — the API populates each only when its
+  // corresponding code is in `blockers`, so a caller can name which
+  // schedules hold the close rather than just that something does.
+  pending_obligation_count?: number
+  pending_obligation_sample?: RawObligationDetail[]
+  earliest_pending_period?: string | null
+  stranded_obligation_count?: number
+  stranded_obligation_sample?: RawObligationDetail[]
+  sync_stale_days?: number | null
   last_close_at: string | null
   initialized_at: string | null
   last_sync_at: string | null
@@ -375,6 +391,8 @@ interface RawInitializeLedgerResult {
 interface RawClosePeriodResult {
   period: string
   entries_posted: number
+  entries_published_to_qb?: number
+  entries_posted_locally?: number
   target_auto_advanced: boolean
   fiscal_calendar: RawFiscalCalendar
   // §3.8 — auto-run rules on close. `null` when no schedules with facts
@@ -404,7 +422,17 @@ export interface InitializeLedgerResult {
 
 export interface ClosePeriodResult {
   period: string
+  /**
+   * Total drafts the close moved to posted, across both post paths. A close
+   * that published everything to QuickBooks used to report 0 here, because
+   * the pre-publish step promotes each draft before the local bulk
+   * transition counts it; both paths are summed now.
+   */
   entriesPosted: number
+  /** Drafts published to QuickBooks by the close's pre-publish step. */
+  entriesPublishedToQb: number
+  /** Drafts posted by the local bulk transition (never reach QuickBooks). */
+  entriesPostedLocally: number
   targetAutoAdvanced: boolean
   fiscalCalendar: LedgerFiscalCalendar
   /**
@@ -466,6 +494,13 @@ export interface InitializeLedgerOptions {
 export interface ClosePeriodOptions {
   note?: string | null
   allowStaleSync?: boolean
+  /**
+   * Close despite matured obligations that were never drafted, knowingly
+   * omitting those adjusting entries. Prefer re-running promotion with
+   * handler dispatch, or voiding the obligations. The override is recorded
+   * in the close audit note.
+   */
+  allowStrandedObligations?: boolean
 }
 
 export interface CreateScheduleOptions {
@@ -1603,6 +1638,7 @@ export class LedgerClient {
       period,
       note: options?.note ?? null,
       allow_stale_sync: options?.allowStaleSync,
+      allow_stranded_obligations: options?.allowStrandedObligations,
     }
     const envelope = await this.callOperation(
       'Close period',
@@ -1612,6 +1648,8 @@ export class LedgerClient {
     return {
       period: raw.period,
       entriesPosted: raw.entries_posted ?? 0,
+      entriesPublishedToQb: raw.entries_published_to_qb ?? 0,
+      entriesPostedLocally: raw.entries_posted_locally ?? 0,
       targetAutoAdvanced: raw.target_auto_advanced ?? false,
       fiscalCalendar: rawFiscalCalendarToCamel(raw.fiscal_calendar),
       ruleSummary: raw.rule_summary ?? null,
@@ -2363,6 +2401,15 @@ export class LedgerClient {
 
 // ── Module-private conversion helpers ─────────────────────────────────
 
+function rawObligationDetailToCamel(raw: RawObligationDetail) {
+  return {
+    eventId: raw.event_id,
+    scheduleId: raw.schedule_id ?? null,
+    scheduleName: raw.schedule_name ?? null,
+    period: raw.period,
+  }
+}
+
 function rawFiscalCalendarToCamel(raw: RawFiscalCalendar): LedgerFiscalCalendar {
   return {
     graphId: raw.graph_id,
@@ -2373,6 +2420,14 @@ function rawFiscalCalendarToCamel(raw: RawFiscalCalendar): LedgerFiscalCalendar 
     catchUpSequence: raw.catch_up_sequence ?? [],
     closeableNow: raw.closeable_now ?? false,
     blockers: raw.blockers ?? [],
+    pendingObligationCount: raw.pending_obligation_count ?? 0,
+    pendingObligationSample: (raw.pending_obligation_sample ?? []).map(rawObligationDetailToCamel),
+    earliestPendingPeriod: raw.earliest_pending_period ?? null,
+    strandedObligationCount: raw.stranded_obligation_count ?? 0,
+    strandedObligationSample: (raw.stranded_obligation_sample ?? []).map(
+      rawObligationDetailToCamel
+    ),
+    syncStaleDays: raw.sync_stale_days ?? null,
     lastCloseAt: raw.last_close_at ?? null,
     initializedAt: raw.initialized_at ?? null,
     lastSyncAt: raw.last_sync_at ?? null,

--- a/clients/graphql/generated/graphql.ts
+++ b/clients/graphql/generated/graphql.ts
@@ -301,10 +301,10 @@ export type EventBlock = {
   externalId: Maybe<Scalars['String']['output']>
   externalUrl: Maybe<Scalars['String']['output']>
   id: Scalars['String']['output']
+  isReconcilingItem: Scalars['Boolean']['output']
   metadata: Scalars['JSON']['output']
   obligatedByEventId: Maybe<Scalars['String']['output']>
   occurredAt: Scalars['DateTime']['output']
-  payloadDrift: Scalars['Boolean']['output']
   replacedByEventId: Maybe<Scalars['String']['output']>
   replacesEventId: Maybe<Scalars['String']['output']>
   resourceElementId: Maybe<Scalars['String']['output']>
@@ -1680,9 +1680,9 @@ export type QueryEventBlocksArgs = {
   agentId?: InputMaybe<Scalars['String']['input']>
   eventCategory?: InputMaybe<Scalars['String']['input']>
   eventType?: InputMaybe<Scalars['String']['input']>
+  isReconcilingItem?: InputMaybe<Scalars['Boolean']['input']>
   limit?: InputMaybe<Scalars['Int']['input']>
   offset?: InputMaybe<Scalars['Int']['input']>
-  payloadDrift?: InputMaybe<Scalars['Boolean']['input']>
   source?: InputMaybe<Scalars['String']['input']>
   status?: InputMaybe<Scalars['String']['input']>
 }
@@ -2896,9 +2896,25 @@ export type GetLedgerFiscalCalendarQuery = {
     catchUpSequence: Array<string>
     closeableNow: boolean
     blockers: Array<string>
+    pendingObligationCount: number
+    earliestPendingPeriod: string | null
+    strandedObligationCount: number
+    syncStaleDays: number | null
     lastCloseAt: any | null
     initializedAt: any | null
     lastSyncAt: any | null
+    pendingObligationSample: Array<{
+      eventId: string
+      scheduleId: string | null
+      scheduleName: string | null
+      period: string
+    }>
+    strandedObligationSample: Array<{
+      eventId: string
+      scheduleId: string | null
+      scheduleName: string | null
+      period: string
+    }>
     periods: Array<{
       name: string
       startDate: any
@@ -5857,6 +5873,36 @@ export const GetLedgerFiscalCalendarDocument = {
                 { kind: 'Field', name: { kind: 'Name', value: 'catchUpSequence' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'closeableNow' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'blockers' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'pendingObligationCount' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'pendingObligationSample' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'eventId' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'scheduleId' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'scheduleName' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'period' } },
+                    ],
+                  },
+                },
+                { kind: 'Field', name: { kind: 'Name', value: 'earliestPendingPeriod' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'strandedObligationCount' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'strandedObligationSample' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'eventId' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'scheduleId' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'scheduleName' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'period' } },
+                    ],
+                  },
+                },
+                { kind: 'Field', name: { kind: 'Name', value: 'syncStaleDays' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'lastCloseAt' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'initializedAt' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'lastSyncAt' } },

--- a/clients/graphql/queries/ledger/fiscalCalendar.ts
+++ b/clients/graphql/queries/ledger/fiscalCalendar.ts
@@ -6,6 +6,13 @@ import { gql } from 'graphql-request'
  * The resolver blends extensions-DB data (calendar + periods) with a
  * platform-DB lookup for QB sync state (last_sync_at). Clients use
  * `closeableNow` + `blockers` as the close gate.
+ *
+ * The obligation and staleness detail fields populate only when their
+ * corresponding blocker code is present, so a UI can name *which* schedules
+ * are holding the close instead of just reporting that something is. They
+ * are selected unconditionally here — the resolver returns 0 / [] / null
+ * when the blocker isn't active, which costs nothing and keeps the document
+ * free of a second round trip for the case that matters most.
  */
 export const GET_FISCAL_CALENDAR = gql`
   query GetLedgerFiscalCalendar {
@@ -18,6 +25,22 @@ export const GET_FISCAL_CALENDAR = gql`
       catchUpSequence
       closeableNow
       blockers
+      pendingObligationCount
+      pendingObligationSample {
+        eventId
+        scheduleId
+        scheduleName
+        period
+      }
+      earliestPendingPeriod
+      strandedObligationCount
+      strandedObligationSample {
+        eventId
+        scheduleId
+        scheduleName
+        period
+      }
+      syncStaleDays
       lastCloseAt
       initializedAt
       lastSyncAt

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -4929,11 +4929,11 @@ export type EventBlockEnvelope = {
         [key: string]: unknown;
     };
     /**
-     * Payload Drift
+     * Is Reconciling Item
      *
-     * True when a source re-sync surfaced a changed upstream payload for an event whose GL is already posted (committed/fulfilled are immutable to sync). The live payload and GL are untouched; the incoming payload is stashed in `metadata.drift_payload` with `metadata.drift_detected_at`. Drifted events need operator reconciliation — the local books no longer mirror the source.
+     * True when this event is a reconciling item: a source re-sync surfaced a changed upstream payload for an event whose GL is already posted (committed/fulfilled are immutable to sync) — the local books legitimately no longer mirror the source, and the difference awaits an explicit disposition (restate the affected months, or book a catch-up entry in the open period). The live payload and GL are untouched; the incoming payload is stashed in `metadata.drift_payload` with `metadata.drift_detected_at`.
      */
-    payload_drift?: boolean;
+    is_reconciling_item?: boolean;
     /**
      * Dimension Ids
      *


### PR DESCRIPTION
Regenerated against `main` with RoboFinSystems/robosystems#1072 in it.

## The rename 1.3.0 missed

1.3.0 shipped `payload_drift` — the name #1072 retired — **27 minutes after** the rename merged to `main`. The cause isn't a race, it's a property of how this SDK is built: **generation reads whatever the local stack is serving, not `main`.** The stack was running a branch cut before #1072 landed, and restarting it faithfully rebuilt that branch. Merging upstream changed nothing about what the container served.

**Not a break.** The change is confined to `sdk/types.gen.ts` — generated internals, explicitly exempt under the versioning policy. No query document selected the field and no facade method exposed it, so nothing consumer-reachable changes. Additive minor.

The lesson worth keeping: `git log origin/main ^HEAD` before generating. A restarted stack reads as "current" while being current only with your own branch.

## Obligation detail on the fiscal calendar

`GET_FISCAL_CALENDAR` now selects what the API has carried since RoboFinSystems/robosystems#1071 but no client could reach.

`blockers` told a caller a close was held; it could not say by what. A close blocked on `stranded_obligations` — matured obligations promoted but never drafted, so closing would silently omit those adjusting entries — surfaced as a bare code with no way to find the schedules responsible. roboledger-app currently renders it as the literal string.

Added to the query: `pendingObligationCount` / `strandedObligationCount`, their up-to-5 samples (`eventId`, `scheduleId`, `scheduleName`, `period`), `earliestPendingPeriod`, `syncStaleDays`. Selected unconditionally — the resolver returns `0` / `[]` / `null` when inactive, so it costs nothing in the common case and saves a round trip in the case that matters.

`ClosePeriodOptions` gains `allowStrandedObligations`, matching a flag `ClosePeriodOperation` already had but the facade couldn't pass.

## Close receipt split

`ClosePeriodResult` gains `entriesPublishedToQb` and `entriesPostedLocally` alongside the corrected `entriesPosted` total — the split #1071 introduced when it fixed a close that published everything to QuickBooks reporting `0` posted.

## Shape parity kept

`LedgerFiscalCalendar` is derived from the GraphQL query type, and `rawFiscalCalendarToCamel` builds the same type from the REST envelope — so extending the query forces the mapper to keep up or the build breaks. `RawFiscalCalendar` and the mapper carry the new fields (with a small `RawObligationDetail` mapper), so the read path and the write path keep returning one shape rather than drifting into two.

## Verification

`npm run test:all` green — prettier, eslint, tsc, 295 tests across 10 files, build clean.