### PR TITLE
chore(sdk): regenerate for FactProvenance arm list correction

### DIFF
--- a/clients/graphql/generated/graphql.ts
+++ b/clients/graphql/generated/graphql.ts
@@ -615,7 +615,7 @@ export type InformationBlockFactSet = {
   id: Scalars['String']['output']
   periodEnd: Scalars['Date']['output']
   periodStart: Maybe<Scalars['Date']['output']>
-  /** Typed ``FactProvenance`` descriptor (discriminated on ``origin``: pivot | schedule | derived | asserted) recording how this FactSet's facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null when the FactSet carries no descriptor. */
+  /** Typed ``FactProvenance`` descriptor (discriminated on ``origin``: pivot | schedule | derived | asserted | document | forecast | filed) recording how this FactSet's facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null when the FactSet carries no descriptor. */
   provenance: Maybe<Scalars['JSON']['output']>
   /** Back-pointer to the parent row in ``reports``. Null when the FactSet does not belong to a report package. */
   reportId: Maybe<Scalars['String']['output']>

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -5367,7 +5367,7 @@ export type FactSetLite = {
     /**
      * Provenance
      *
-     * Typed ``FactProvenance`` descriptor (discriminated on ``origin``: pivot | schedule | derived | asserted) recording how this FactSet's facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null when the FactSet carries no descriptor.
+     * Typed ``FactProvenance`` descriptor (discriminated on ``origin``: pivot | schedule | derived | asserted | document | forecast | filed) recording how this FactSet's facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null when the FactSet carries no descriptor.
      */
     provenance?: {
         [key: string]: unknown;


### PR DESCRIPTION
## Summary

Regenerates the SDK types and GraphQL types against the current upstream API surface. Picks up the `FactProvenance` arm-list correction in the `FactSet.provenance` description (robosystems `48b0ecf1`, released in v1.7.4).

Documentation-only: the `origin` discriminator list in the `provenance` field description now reads `pivot | schedule | derived | asserted | document | forecast | filed` instead of the stale four-arm list.

## Changes

- `sdk/types.gen.ts` — `FactSetLite.provenance` docstring
- `clients/graphql/generated/graphql.ts` — `InformationBlockFactSet.provenance` docstring

## Compatibility

No public-surface change — types, method signatures, and runtime behavior are unchanged. Patch-level.

## Test plan

- [x] `npm run test:all` via pre-commit hook (prettier, eslint, tsc, 295 tests, build)