### PR TITLE
feat(sdk): regenerate for the backup encryption field removal

### DIFF
--- a/sdk/sdk.gen.ts
+++ b/sdk/sdk.gen.ts
@@ -623,7 +623,7 @@ export const listBackups = <ThrowOnError extends boolean = false>(options: Optio
 /**
  * Get temporary download URL for backup
  *
- * Generate a temporary download URL for a backup (unencrypted backups only). The filename carries the extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first: `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
+ * Generate a temporary download URL for a backup. The filename carries the extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first: `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
  */
 export const getBackupDownloadUrl = <ThrowOnError extends boolean = false>(options: Options<GetBackupDownloadUrlData, ThrowOnError>) => (options.client ?? client).get<GetBackupDownloadUrlResponses, GetBackupDownloadUrlErrors, ThrowOnError>({
     security: [{ name: 'X-API-Key', type: 'apiKey' }, { scheme: 'bearer', type: 'http' }],
@@ -1044,7 +1044,7 @@ export const createBackup = <ThrowOnError extends boolean = false>(options: Opti
 /**
  * Restore Backup
  *
- * Only encrypted backups can be restored. Not allowed on entity graphs (use `materialize` instead) or shared repositories.
+ * Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the existing database is snapshotted, then overwritten. Monitor progress via SSE at `/v1/operations/{operation_id}/stream`.
  *
  * **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
  */

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -753,12 +753,6 @@ export type BackupCreateRequest = {
      */
     compression?: boolean;
     /**
-     * Encryption
-     *
-     * Enable encryption (encrypted backups cannot be downloaded)
-     */
-    encryption?: boolean;
-    /**
      * Schedule
      *
      * Optional cron schedule for automated backups
@@ -855,6 +849,12 @@ export type BackupListResponse = {
      */
     is_shared_repository?: boolean;
     /**
+     * Restore Supported
+     *
+     * Whether backups on this graph can be restored. False for entity graphs, which are materialized from the extensions database (use the materialize operation instead), and for shared repositories, which are platform-managed and download-only.
+     */
+    restore_supported?: boolean;
+    /**
      * Download quota for shared repositories
      */
     download_quota?: DownloadQuota | null;
@@ -911,21 +911,13 @@ export type BackupResponse = {
      */
     backup_duration_seconds: number;
     /**
-     * Encryption Enabled
-     */
-    encryption_enabled: boolean;
-    /**
      * Compression Enabled
      */
     compression_enabled: boolean;
     /**
-     * Allow Export
-     */
-    allow_export: boolean;
-    /**
      * Download Extension
      *
-     * Extension the download will carry, and therefore how to unpack it: '.lbug.zip' is a ZIP holding the LadybugDB database file, '.lbug.zst' is zstd-compressed (`zstd -d`). Null when the backup is encrypted and so cannot be downloaded.
+     * Extension the download will carry, and therefore how to unpack it: '.lbug.zip' is a ZIP holding the LadybugDB database file, '.lbug.zst' is zstd-compressed (`zstd -d`). Null only when the backup has no stored object yet.
      */
     download_extension?: string | null;
     /**
@@ -19723,7 +19715,7 @@ export type GetBackupDownloadUrlData = {
 
 export type GetBackupDownloadUrlErrors = {
     /**
-     * Access denied or backup is encrypted
+     * Access denied
      */
     403: unknown;
     /**


### PR DESCRIPTION
Regenerated against [RoboFinSystems/robosystems#refactor/backup-drop-encryption-flag](https://github.com/RoboFinSystems/robosystems/tree/refactor/backup-drop-encryption-flag), which retires the backup `encryption` flag.

The flag never encrypted anything at the application layer — it only suppressed downloads, and because it defaulted to `false`, the default backup was unrestorable. Restore is now gated on graph type instead, and every completed backup is downloadable. Objects remain encrypted at rest with S3 SSE-AES256 and are served over TLS through short-lived signed URLs.

## Contract changes

| Type | Change |
| --- | --- |
| `BackupListResponse` | **adds** `restore_supported?: boolean` |
| `BackupCreateRequest` | **removes** `encryption` |
| `BackupResponse` | **removes** `encryption_enabled`, `allow_export` |

`restore_supported` is false for entity graphs (materialized from the extensions database — use `materialize`) and for shared repositories (platform-managed, download-only).

Also picks up description edits: `download_extension` no longer claims null-when-encrypted, and `getBackupDownloadUrl`'s 403 is no longer "or backup is encrypted".

## Versioning

Intended as a **minor**. Removing response fields is a compile-break for a consumer that reads them, which strict semver would call a major — but nothing reads them: the flag has no effect on any operation and `allow_export` was always its inverse. Verified no references in `robosystems-app`, `@robosystems/core`, `roboledger-app`, or `roboinvestor-app`. Called deliberately rather than carrying dead fields through a deprecation cycle.

An earlier regen widened `encryption_enabled` and `allow_export` from `boolean` to `boolean | undefined` — that would have been a genuine breaking read. Fixed upstream before this regen; the diff here is pure removals plus the one addition.

## Verification

`npm run test:all` — 295 tests, eslint, tsc, prettier all clean.

Merge after the upstream API PR.