### PR TITLE
chore: regenerate against the v1.7.8 API surface

### DIFF
--- a/sdk/sdk.gen.ts
+++ b/sdk/sdk.gen.ts
@@ -1044,7 +1044,7 @@ export const createBackup = <ThrowOnError extends boolean = false>(options: Opti
 /**
  * Restore Backup
  *
- * Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the existing database is snapshotted, then overwritten. Monitor progress via SSE at `/v1/operations/{operation_id}/stream`.
+ * Not allowed on entity graphs (use `materialize` instead) or shared repositories. Entity *subgraphs* are restorable — they are written directly and have no materialization path. Destructive: the existing database is snapshotted, then overwritten. Monitor progress via SSE at `/v1/operations/{operation_id}/stream`.
  *
  * **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
  */

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -851,7 +851,7 @@ export type BackupListResponse = {
     /**
      * Restore Supported
      *
-     * Whether backups on this graph can be restored. False for entity graphs, which are materialized from the extensions database (use the materialize operation instead), and for shared repositories, which are platform-managed and download-only.
+     * Whether backups on this graph can be restored. False for entity graphs, which are materialized from the extensions database (use the materialize operation instead), and for shared repositories, which are platform-managed and download-only. True for subgraphs of an entity graph: only the parent is materialized, so a subgraph has no other recovery path.
      */
     restore_supported?: boolean;
     /**
@@ -14144,7 +14144,7 @@ export type StorageSummary = {
     /**
      * Avg Storage Gb
      *
-     * Average storage in GB
+     * Time-weighted average storage in GB over the period
      */
     avg_storage_gb: number;
     /**
@@ -14159,12 +14159,6 @@ export type StorageSummary = {
      * Minimum storage in GB
      */
     min_storage_gb: number;
-    /**
-     * Total Gb Hours
-     *
-     * Total GB-hours for billing
-     */
-    total_gb_hours: number;
     /**
      * Measurement Count
      *


### PR DESCRIPTION
## What

One behavioural change, two documentation ones.

### `StorageSummary.total_gb_hours` removed

The server retired it in [robosystems#1107](https://github.com/RoboFinSystems/robosystems/pull/1107). It was a **storage-billing unit, and there is no storage billing** — the overage column is never written, the billing config has no storage entries, and storage is included in the tier. The field described a mechanism that had been removed.

`avg_storage_gb` is now documented as **time-weighted**: each reading weighted by the span since the previous one, so an irregular snapshot cadence doesn't skew it.

### Descriptive only

From [robosystems#1105](https://github.com/RoboFinSystems/robosystems/pull/1105): restore is allowed on entity **subgraphs** — they're written directly and have no materialization path, so a subgraph has no other recovery route.

## On the version

This removes a field from a response type, which the 1.0 contract would normally make a **major**. It rides as a patch deliberately:

**The server change already shipped.** The field is gone from the API, so a type still declaring it would be describing a response it can never receive. There's nothing to deprecate-then-remove — the client is catching up to the wire, not initiating the break. A deprecation cycle only makes sense when you control removal timing on both sides.

If you'd want strictness on a future one, the lever is server-side sequencing: deprecate in the API first, remove a cycle later, client follows in step.

No known consumer reads it (`robosystems-app` greps clean).

## Gate

`npm run test:all` — the full chain, not typecheck-and-test: **format:check** (Prettier), **lint** (ESLint), **typecheck** (tsc), **295 tests**, **build**. All clean.