### PR TITLE
chore: regenerate for the forecast verification halt [HOLD — needs robosystems#1109]

### DIFF
--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -1651,6 +1651,12 @@ export type ComputeForecastResponse = {
      */
     months_computed?: Array<ForecastMonthLite>;
     /**
+     * Halted At
+     *
+     * Month (``YYYY-MM``) where the walk stopped because verification failed, or null if it ran the full horizon. Each month's opening balances are the previous month's closing balances, so computing past a failure yields months derived from a known-wrong one rather than merely unverified months. When set, ``months_computed`` ends at this month and is shorter than ``months``; the failing month's facts are kept so the failure can be inspected.
+     */
+    halted_at?: string | null;
+    /**
      * Skipped
      */
     skipped?: Array<SkippedForecastLite>;
@@ -5837,7 +5843,7 @@ export type ForecastMonthLite = {
     /**
      * Verification Passed
      *
-     * Whether every rule evaluated against the month's scenario sets passed (None = no rules ran for the month).
+     * Whether every rule evaluated against the month's scenario sets passed. Three states, and the third is not the first: ``true`` = rules ran and all passed; ``false`` = at least one failed or errored, which halts the walk (see ``halted_at``); ``null`` = **no rules ran**, so the month is unverified rather than verified. Treat null as absence of evidence, never as a pass.
      */
     verification_passed?: boolean | null;
     /**


### PR DESCRIPTION
## ⚠️ Do not merge before [robosystems#1109](https://github.com/RoboFinSystems/robosystems/pull/1109)

This was regenerated against a **local stack carrying that branch**, not against `origin/main`. The server does not return `halted_at` yet and does not halt. Merging and publishing first would ship a client documenting behaviour the deployed API doesn't have — including a description telling integrators that `false` halts the walk, when the deployed server never halts.

Additive, so no version concern — purely an ordering one.

## What

**`ComputeForecastResponse.halted_at?: string | null`** — the month where the forecast walk stopped because verification failed, or null if it ran the full horizon.

Each month's opening balances are the previous month's closing balances, so computing past a failure doesn't yield merely *unverified* months — it yields months **derived from a known-wrong one**. The walk now stops and names where, and `months_computed` ends there.

**`ForecastMonthLite.verification_passed`** — same type, honest description. Tri-state, and the third state is not the first:

| Value | Meaning |
|---|---|
| `true` | rules ran, all passed |
| `false` | something failed — halts the walk |
| `null` | **no rules ran** — unverified, not verified |

Consumers had been treating `null` and `true` alike, which meant a rule corpus that silently stopped binding would have looked like a passing forecast.

## Gate

`npm run test:all` — the full chain rather than typecheck-and-test: **format:check** (Prettier), **lint**, **typecheck**, **295 tests**, **build**. All clean.