### PR TITLE
docs: state the 1.x two-tier compatibility promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Official TypeScript Client for the RoboSystems Financial Knowledge Graph API. Ac
 npm install @robosystems/client
 ```
 
+## Versioning
+
+This client is `1.x` and follows semantic versioning, with one distinction worth knowing before you pin.
+
+The **stable surface** is the facade clients and their subpath exports (`/clients`, `/ledger`, `/investor`, `/library`, `/query`, `/operations`, `/client`), the React hooks, the error classes, the auth configuration, and the types those signatures expose through `/types`. It is frozen for the life of `1.x`; breaking any of it costs a major version.
+
+The **generated surface** — `/sdk`, which publishes the code generated from the platform's OpenAPI spec — tracks that spec. Operations there can be added, renamed, or removed on a minor release, and every such removal is named in that release's notes. `/sdk` is exported for convenience, not promised; anything that earns a compatibility promise is surfaced through a facade first.
+
+So `^1` is the right pin if you build on the facades. If you import from `/sdk`, either pin a minor range (`~1.7`) and read the release notes when you widen, or open an issue to have the operation surfaced through a facade.
+
 ## Resources
 
 - [RoboSystems Platform](https://robosystems.ai)


### PR DESCRIPTION
## Why

The 1.0 contract listed `/sdk` as public surface and exempted `sdk/*.gen.ts` as a generated internal in the very next clause. Consumers had no way to tell which half applied — and the README said nothing about versioning at all.

## What the promise is

- **Stable surface** — the facade clients and their subpath exports (`/clients`, `/ledger`, `/investor`, `/library`, `/query`, `/operations`, `/client`), React hooks, error classes, auth config, and the types those signatures expose through `/types`. Frozen for the life of `1.x`.
- **Generated surface** — `/sdk`, which republishes the generated code and tracks the OpenAPI spec. Operations there can move on a minor, with removals named in the release notes. Exported for convenience, not promised; anything that earns a promise is surfaced through a facade first.

Resolved toward what is already true rather than toward the stricter reading: no facade referenced any of the operations dropped from the generated tier across the recent minors, so those releases were correctly classified.

`robosystems-app` consumes the raw client and so is exposed to generated-tier movement. That is a first-party build break caught in its own CI, not a contract break — and not a reason to promote `/sdk`, since gating a published SDK on a frontend's build is coupling that gets disabled the first time it is inconvenient.

## Related

- `RoboFinSystems/robosystems-python-client` — the parallel change, where the line is drawn by the integration template
- `RoboFinSystems/robosystems-integration-template` — states that the template defines the Python client's stable surface