### PR TITLE
Align positioning with the platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/@robosystems%2Fclient.svg)](https://www.npmjs.com/package/@robosystems/client)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Official TypeScript Client for the RoboSystems Financial Knowledge Graph API. Access comprehensive financial data including accounting transactions, financial reports, and advanced graph analytics through a type-safe, modern TypeScript interface.
+Official TypeScript client for the RoboSystems financial intelligence platform — accounting, financial reporting, and investment management over a knowledge graph API. Type-safe and modern, generated from the OpenAPI spec, with GraphQL reads and idempotent operation writes.
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@robosystems/client",
   "version": "1.8.0",
-  "description": "TypeScript client library for RoboSystems Financial Knowledge Graph API",
+  "description": "TypeScript client library for the RoboSystems financial intelligence platform",
   "main": "index.js",
   "types": "index.d.ts",
   "bin": {


### PR DESCRIPTION
The README and the npm description both opened on **"the RoboSystems Financial Knowledge Graph API"** — the naming the platform retired in favor of *"financial intelligence platform for accounting, financial reporting, and investment management."*

Part of a sweep aligning every surface on that framing: the repo README, the wiki, and the GitHub repo descriptions across the org were updated alongside this.

| File | Surface it feeds |
| --- | --- |
| `README.md` | GitHub repo page |
| `package.json` | **npm package subtitle** — what a consumer sees first |

The `package.json` line is the one that mattered: it is the description rendered on the npm listing, so the drift was not cosmetic. It reaches npm on the next publish; the GitHub description is already live, so the two are briefly out of step until then.

No version bump, no public-surface change — neither the facade nor the generated tier is touched. Pre-commit gate green: prettier, lint, typecheck, 302 tests passed.