### PR TITLE
Regenerate for named SQL parameters and operator descriptions

### DIFF
--- a/sdk/sdk.gen.ts
+++ b/sdk/sdk.gen.ts
@@ -549,7 +549,7 @@ export const listOperators = <ThrowOnError extends boolean = false>(options: Opt
 /**
  * Auto-select Operator for Query
  *
- * Routes to the best operator for your query. Operators: `financial` (SEC, accounting), `research` (deep analysis), `rag` (knowledge base, free). Credit cost by mode: `quick` 5-10, `standard` 15-25, `extended` 30-75. Execution strategy (sync/SSE/async) auto-selected; override with `?mode=sync|async`.
+ * Routes to the best operator for your query. Operators: `cypher` (answers natural-language questions by querying the graph; supports `quick`, `standard`, `extended`) and `mapping` (autonomous Chart of Accounts → rs-gaap mapping; roboledger graphs only, `extended` only). `GET /v1/graphs/{graph_id}/operator` lists what is registered. Credits are consumed by actual token usage, not a fixed price per mode. Execution strategy (sync/SSE/async) auto-selected; override with `?mode=sync|async`.
  */
 export const autoSelectOperator = <ThrowOnError extends boolean = false>(options: Options<AutoSelectOperatorData, ThrowOnError>) => (options.client ?? client).post<AutoSelectOperatorResponses, AutoSelectOperatorErrors, ThrowOnError>({
     security: [{ name: 'X-API-Key', type: 'apiKey' }, { scheme: 'bearer', type: 'http' }],
@@ -573,7 +573,7 @@ export const getOperatorMetadata = <ThrowOnError extends boolean = false>(option
 /**
  * Execute Specific Operator
  *
- * Available: `financial` (SEC filings, accounting), `research` (deep analysis), `rag` (retrieval, no credits). Execution strategy auto-selected; override with `?mode=sync|async`.
+ * Available: `cypher` (natural-language questions answered by querying the graph; RAG retrieval is one of its capabilities, not a separate operator) and `mapping` (Chart of Accounts → rs-gaap mapping, roboledger graphs only). `GET /v1/graphs/{graph_id}/operator` lists what is registered. Execution strategy auto-selected; override with `?mode=sync|async`.
  */
 export const executeSpecificOperator = <ThrowOnError extends boolean = false>(options: Options<ExecuteSpecificOperatorData, ThrowOnError>) => (options.client ?? client).post<ExecuteSpecificOperatorResponses, ExecuteSpecificOperatorErrors, ThrowOnError>({
     security: [{ name: 'X-API-Key', type: 'apiKey' }, { scheme: 'bearer', type: 'http' }],

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -8412,7 +8412,7 @@ export type LiveFinancialStatementRequest = {
     /**
      * Statement Type
      *
-     * income_statement | balance_sheet | equity_statement
+     * income_statement | balance_sheet | cash_flow_statement | equity_statement
      */
     statement_type: string;
     /**
@@ -14259,9 +14259,11 @@ export type SqlStatementRequest = {
     /**
      * Parameters
      *
-     * Query parameters for safe value substitution. ALWAYS use parameters instead of string concatenation.
+     * Query parameters for safe value substitution. ALWAYS use parameters instead of string concatenation. Pass a list for positional placeholders (`?` or `$1`) and an object for named ones (`$param_name`) — the two forms cannot be mixed in one statement.
      */
-    parameters?: Array<unknown> | null;
+    parameters?: Array<unknown> | {
+        [key: string]: unknown;
+    } | null;
 };
 
 /**


### PR DESCRIPTION
Routine regeneration against the current `main` API surface — the TypeScript counterpart to robosystems-python-client#184. Three changes came across, one of them a real type widening rather than prose.

## What changed

**`SqlStatementRequest.parameters` accepts an object as well as an array.** The API-side field is now `list[Any] | dict[str, Any] | None`, so named placeholders (`$param_name`) are expressible alongside positional ones (`?` / `$1`) — the two forms still cannot be mixed in one statement. The generated type widens to `Array<unknown> | { [key: string]: unknown } | null`.

**Operator descriptions now name the operators that exist.** They advertised `financial`, `research`, and `rag` with fixed per-mode credit prices (`quick` 5-10, `standard` 15-25, `extended` 30-75). What is actually registered is `cypher` and `mapping`, and credits are consumed by real token usage, not a per-mode price. The new text also points at `GET /v1/graphs/{graph_id}/operator` as the live answer, so the docstring cannot drift the same way again.

**`LiveFinancialStatementRequest.statement_type`** lists `cash_flow_statement` among its statement types.

## Compatibility

Generated tier, additive: a widened request-field union plus doc comments. No removals, no facade change. Rides a minor; no deprecation cycle and no curated release notes required.

## Verification

Each of the three source-side changes was confirmed present at `robosystems` `origin/main`, not just on a local feature branch, so the regeneration reflects merged API state.

`npm run test:all` green via the pre-commit gate: 302 tests across 10 files, prettier + eslint + tsc clean, build passes.