### PR TITLE
Regenerate for purged report ids on the block result

### DIFF
--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -1200,6 +1200,12 @@ export type BlockSourceGraphResult = {
      * Number of previously-shared reports deleted from this graph. Zero unless `purge` was set.
      */
     purged_report_count?: number;
+    /**
+     * Purged Report Ids
+     *
+     * Ids of the previously-shared reports deleted from this graph. Empty unless `purge` was set.
+     */
+    purged_report_ids?: Array<string>;
 };
 
 /**


### PR DESCRIPTION
## Summary

Blocking a source graph with `purge` now reports *which* reports it removed, not only how many. Regenerated against RoboFinSystems/robosystems#1126, which adds `purged_report_ids` to the block result so a recipient can reconcile exactly what left their graph instead of inferring it from a count.

## Changes

- `sdk/types.gen.ts` — one new optional property on `BlockSourceGraphResult`: `purged_report_ids?: Array<string>`.

That is the entire diff: +6 lines, one file. No endpoint was added, removed or resignatured, so `sdk.gen.ts` is untouched, and nothing under the hand-written surface moved.

**The GraphQL schema is unchanged.** The upstream change alters authorization on existing report reads rather than the schema they expose, so the typed GraphQL surface is not regenerated here. (Verified on the Python client, whose checked-in SDL snapshot reported "already current" when refreshed against a backend running that branch — this repo's equivalent snapshot gate is still pending.)

## Compatibility

ADDITIVE

Diffed the emitted types before classifying, per the template's warning. The new property is optional, no existing property changed type or became required, and nothing was removed or narrowed. `purged_report_count` is untouched and still populated, so a consumer reading only the count is unaffected.

Nothing here touches the stable tier — no facade, no root export.

## Testing

- `npm run test:all` — passed via the pre-commit hook: 302 tests across 10 files, prettier, eslint, tsc.
- `npm run build` — passed (`tsc` clean).
- Verified by hand that the emitted description matches the corrected upstream text; an earlier regen carried a description explaining why the *server* also reads the field, which does not belong in published client docs.

## Release sequencing

**Do not publish before robosystems#1126 merges and deploys.** The property is optional, so a client ahead of the API is harmless at runtime — it simply never arrives — but until then the package would document a response field the deployed API does not return.

No version bump in this PR.
