### PR TITLE
chore(sdk): regenerate from API 1.8.3 — passkey re-auth proof fields

### DIFF
--- a/sdk/sdk.gen.ts
+++ b/sdk/sdk.gen.ts
@@ -181,10 +181,9 @@ export const completeSsoAuth = <ThrowOnError extends boolean = false>(options: O
 /**
  * Passkey Registration Options
  *
- * Begin a passkey enrollment ceremony.
+ * Begin a passkey enrollment ceremony. The settings lane requires a fresh re-auth proof (password or assertion); the forced lane presents its enrollment token.
  */
 export const getPasskeyRegistrationOptions = <ThrowOnError extends boolean = false>(options: Options<GetPasskeyRegistrationOptionsData, ThrowOnError>) => (options.client ?? client).post<GetPasskeyRegistrationOptionsResponses, GetPasskeyRegistrationOptionsErrors, ThrowOnError>({
-    security: [{ name: 'X-API-Key', type: 'apiKey' }],
     url: '/v1/auth/passkeys/register/options',
     ...options,
     headers: {
@@ -199,7 +198,6 @@ export const getPasskeyRegistrationOptions = <ThrowOnError extends boolean = fal
  * Finish enrollment. The first passkey returns recovery codes (once); the forced-enrollment lane also completes the login.
  */
 export const verifyPasskeyRegistration = <ThrowOnError extends boolean = false>(options: Options<VerifyPasskeyRegistrationData, ThrowOnError>) => (options.client ?? client).post<VerifyPasskeyRegistrationResponses, VerifyPasskeyRegistrationErrors, ThrowOnError>({
-    security: [{ name: 'X-API-Key', type: 'apiKey' }],
     url: '/v1/auth/passkeys/register/verify',
     ...options,
     headers: {
@@ -1611,7 +1609,7 @@ export const createCheckoutSession = <ThrowOnError extends boolean = false>(opti
 /**
  * Get Checkout Session Status
  *
- * Poll after returning from Stripe Checkout. Status progresses: pending_payment → provisioning → active. When active, resource_id is populated; for graphs, operation_id tracks SSE provisioning progress.
+ * Poll after returning from Stripe Checkout. Status progresses: pending_payment → provisioning → active. When active, resource_id is populated. `operation_id` is always null for webhook-driven provisioning and cannot be used to follow progress — poll this endpoint instead.
  */
 export const getCheckoutStatus = <ThrowOnError extends boolean = false>(options: Options<GetCheckoutStatusData, ThrowOnError>) => (options.client ?? client).get<GetCheckoutStatusResponses, GetCheckoutStatusErrors, ThrowOnError>({
     security: [{ name: 'X-API-Key', type: 'apiKey' }, { scheme: 'bearer', type: 'http' }],

--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -1568,7 +1568,7 @@ export type CheckoutStatusResponse = {
     /**
      * Operation Id
      *
-     * SSE operation ID for monitoring provisioning progress
+     * Always null. Webhook-driven provisioning passes no operation id (`_trigger_resource_provisioning` calls `run_graph_provisioning` with `operation_id=None`), so there is no SSE stream to follow — poll the status endpoint instead. Retained rather than removed because it is on a published response shape; wiring it is a feature, not a fix.
      */
     operation_id?: string | null;
     /**
@@ -5678,6 +5678,12 @@ export type FileUploadRequest = {
      * Table name to associate file with (required for first-class /files endpoint)
      */
     table_name?: string | null;
+    /**
+     * File Size Bytes
+     *
+     * Size of the file about to be uploaded, in bytes. Optional; when supplied, an over-limit file is rejected here instead of after it has been pushed to S3 and rejected by ingest-file. Advisory only — the authoritative check measures the object after upload.
+     */
+    file_size_bytes?: number | null;
 };
 
 /**
@@ -11739,8 +11745,13 @@ export type PasskeyLoginVerifyRequest = {
 /**
  * PasskeyRegisterOptionsRequest
  *
- * Begin enrollment. mfa_token is the forced-enrollment lane; omitted for
- * an authenticated settings-flow enrollment.
+ * Begin enrollment.
+ *
+ * Two disjoint lanes: ``mfa_token`` (forced enrollment — the token was minted
+ * seconds after a password verify, so it is its own freshness proof) or an
+ * authenticated settings-flow enrollment, which must carry a fresh re-auth
+ * proof — ``password``, or a ``reauth``-ceremony ``assertion`` when adding a
+ * passkey beside an existing one.
  */
 export type PasskeyRegisterOptionsRequest = {
     /**
@@ -11749,6 +11760,20 @@ export type PasskeyRegisterOptionsRequest = {
      * Enrollment token from a login that returned mfa_enrollment_required
      */
     mfa_token?: string | null;
+    /**
+     * Password
+     *
+     * Current password — settings-lane re-authentication
+     */
+    password?: string | null;
+    /**
+     * Assertion
+     *
+     * Fresh WebAuthn assertion from the re-auth ceremony (settings lane)
+     */
+    assertion?: {
+        [key: string]: unknown;
+    } | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

Regeneration against the merged API (robosystems#1164, #1165, #1161, #1163 — spec version 1.8.3). Strictly additive: client minor.

## Changes

- `PasskeyRegisterOptionsRequest` gains optional `password`/`assertion` (the settings-lane re-auth proof; forced lane unchanged). The two register endpoints drop their `X-API-Key` security entry — they are JWT-session-or-token surfaces now. Core 0.8.1's localized body cast can drop once this publishes.
- `FileUploadRequest.file_size_bytes` — optional advisory pre-check (from robosystems#1161).
- `CheckoutStatusResponse.operation_id` description now says it is always null for webhook-driven provisioning (from robosystems#1163).

SCIM changes in #1165 never reach the spec (schema-excluded).

## Breaking Changes

None — additive fields and description updates only.

## Testing

`npm run test:all` green — 10 files, 302 tests; GraphQL generation byte-identical (no schema drift).