### PR TITLE
chore(sdk): add OrgInvitationResponse.token field (robosystems #1166)

### DIFF
--- a/sdk/types.gen.ts
+++ b/sdk/types.gen.ts
@@ -11432,6 +11432,12 @@ export type OrgInvitationResponse = {
      * Is Expired
      */
     is_expired: boolean;
+    /**
+     * Token
+     *
+     * Test-support only: the raw invite token. Populated ONLY when AUTH_INVITE_TOKEN_IN_RESPONSE is enabled in a non-production environment; always null in production. Lets automated authorization tests complete the invite -> register flow without email interception.
+     */
+    token?: string | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

Regenerates `sdk/types.gen.ts` to include the new optional `token` field on `OrgInvitationResponse`, added upstream in robosystems [#1166](https://github.com/RoboFinSystems/robosystems/pull/1166).

## Change

- Additive: `token?: string | null` on `OrgInvitationResponse`. The diff is scoped to this one field, nothing else regenerated.
- Documented as test-support only: the API populates it **only** when `AUTH_INVITE_TOKEN_IN_RESPONSE` is enabled in a non-production environment, and it is **always null in production** (it lets automated authorization tests complete the invite → register flow without email interception).

## Contract

- **Generated-tier (`sdk/*.gen.ts`), additive → rides a client minor.** Not a facade/stable-tier change; an added optional field breaks nothing. No deprecation, no release notes required.
- No version bump (user-owned via create-release).

## Sequencing

Originates in robosystems #1166, which is **open, not yet merged/deployed** (prod on API 1.8.3). The field is optional, so this client is forward-compatible against the current API — it is simply always absent until #1166 lands. If #1166's review changes the field (e.g. excludes it from the schema), re-regenerate before publishing.
