### PR TITLE
revert(ci): drop the automatic PR review trigger, keep the author gate

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,8 +1,6 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -12,29 +10,13 @@ on:
   pull_request_review:
     types: [submitted]
 
-# One review per PR at a time. A rapid draft->ready->draft toggle would otherwise
-# stack runs and burn Claude usage on states nobody is waiting for.
-concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   claude:
     # Defense-in-depth author gate: only run when the triggering actor is a repo
-    # OWNER/MEMBER/COLLABORATOR, so a drive-by comment or a fork PR from an
-    # outside account cannot invoke Claude or drain Claude usage. This repo is
-    # public, so the gate is load-bearing, not decorative.
-    #
-    # The pull_request arm reviews every PR opened by an org member — the
-    # compensating control for CC8.1, since a sole maintainer cannot approve
-    # their own PR. It is `pull_request`, never `pull_request_target`, so a fork
-    # PR carries no secrets even in the case where it somehow ran.
+    # OWNER/MEMBER/COLLABORATOR, so a drive-by comment from an outside account
+    # cannot invoke Claude or drain Claude usage. This repo is public, so the
+    # gate is load-bearing, not decorative.
     if: |
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      ) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
@@ -63,14 +45,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # On the automatic pull_request trigger there is no comment to act on, so
-          # supply the review brief. Left empty for comment-driven events so Claude
-          # follows the instructions in the comment that tagged it.
-          #
-          # Deliberately does NOT approve: org policy sets
-          # can_approve_pull_request_reviews=false, and an unconditional bot approval
-          # on every PR is a rubber stamp - worse audit evidence than none.
-          prompt: ${{ github.event_name == 'pull_request' && 'Review this pull request. This repository is a published SDK on a post-1.0 semver contract with external integrators, maintained by a single engineer who cannot approve their own PRs, so this review is the compensating change-management control - be substantive rather than cursory. Focus on correctness bugs, whether anything touches the stable tier (SDK facades, root exports, error classes, auth config, and the symbols the integration template imports) which would require a coordinated client major, and whether the PR description matches the diff. Post your findings as a comment. Do not approve the pull request.' || '' }}
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

Reverts the automatic PR review trigger added earlier today. It fired on every pull request and **never once posted a review**, while each run concluded `success` and cost $0.20–$1.12.

The comment-triggered path was never broken. `/create-pr` posts `@claude please review this PR` on every PR it opens, and that path demonstrably works. A working control invoked by the command beats a broken one wired to an event.

## What went wrong

Three obstacles, hit in sequence:

1. **Anti-tampering guard** — `claude-code-action` refuses to run when the workflow file on a PR branch differs from the default branch, so the rollout PRs could not test themselves.
2. **Token permissions** — the job declared `pull-requests: read`; posting a comment is a write. Fixed, and it was not the cause.
3. **Tool permission denials** — with the trigger live and write granted, a run still posted nothing: `num_turns: 33`, `total_cost_usd: 1.12`, `permission_denials_count: 15`. These are Claude Code's own tool-permission layer rather than GitHub rejections, and the root cause is unresolved.

## Changes

**`.github/workflows/claude.yml`**
- Removed the `pull_request` trigger.
- Removed the `concurrency` group. It existed to de-duplicate draft/ready toggles on that trigger; on comment-driven runs it would *cancel a legitimate in-progress review*, so it is actively wrong without the trigger.
- Removed the automation `prompt`, restoring the commented-out original.
- Restored `pull-requests` / `issues` to `read` (robosystems only — the repo where they were bumped).

## Kept deliberately

**The `author_association` gate stays.** Several of these workflows had no gate at all and would run for any commenter on a public repository — a real hole that predates today's work and is unrelated to the trigger. All four comment arms remain restricted to `OWNER`/`MEMBER`/`COLLABORATOR`.

## Breaking Changes

None. CI configuration only.

## Testing

Each workflow parsed with `yaml.safe_load` and asserted on: no `pull_request` trigger, no `concurrency` block, no `pull_request` arm in the job gate, no automation prompt, permissions at `read`, and the four author gates intact.
